### PR TITLE
`each :subtree` displays the total # of targets instead of subprojects

### DIFF
--- a/src/leiningen/monolith.clj
+++ b/src/leiningen/monolith.clj
@@ -201,10 +201,9 @@
     (let [config (config/read!)
           subprojects (get-subprojects project config)
           start-from (some-> (:start opts) ffirst read-string)
-          relevant-subprojects (-> (dependency-map subprojects)
-                                   (cond->
-                                     (:subtree opts)
-                                       (u/subtree-from (project-sym project))))
+          relevant-subprojects (cond-> (dependency-map subprojects)
+                                 (:subtree opts)
+                                 (u/subtree-from (project-sym project)))
           targets (-> relevant-subprojects
                       (u/topological-sort)
                       (->> (map-indexed vector))

--- a/src/leiningen/monolith.clj
+++ b/src/leiningen/monolith.clj
@@ -201,9 +201,11 @@
     (let [config (config/read!)
           subprojects (get-subprojects project config)
           start-from (some-> (:start opts) ffirst read-string)
-          targets (-> (dependency-map subprojects)
-                      (cond->
-                        (:subtree opts) (u/subtree-from (project-sym project)))
+          relevant-subprojects (-> (dependency-map subprojects)
+                                   (cond->
+                                     (:subtree opts)
+                                       (u/subtree-from (project-sym project))))
+          targets (-> relevant-subprojects
                       (u/topological-sort)
                       (->> (map-indexed vector))
                       (cond->>
@@ -220,7 +222,7 @@
             (lein/info (format "\nApplying to %s (%s/%s)"
                                (ansi/sgr subproject-name :bold :yellow)
                                (ansi/sgr (inc i) :cyan)
-                               (ansi/sgr (count subprojects) :cyan)))
+                               (ansi/sgr (count relevant-subprojects) :cyan)))
             (lein/apply-task (first task) (get subprojects subproject-name) (rest task)))
           (catch Exception ex
             ; TODO: report number skipped, number succeeded, number remaining?


### PR DESCRIPTION
before:
```
lib-b$ lein monolith each :subtree install
Applying install to 2 subprojects...

Applying to example/lib-a (1/3)
...
Applying to example/lib-b (2/3)
...
```
after:
```
Applying to example/lib-a (1/2)
...
Applying to example/lib-b (2/2)
...
```