### PR TITLE
More 'each' opts

### DIFF
--- a/example/apps/app-a/project.clj
+++ b/example/apps/app-a/project.clj
@@ -1,6 +1,7 @@
 (defproject example/app-a "0.5.0"
   :description "Example project with internal and external dependencies."
   :monolith/inherit true
+  :deployable true
 
   :dependencies
   [[commons-io "2.5"]

--- a/example/project.clj
+++ b/example/project.clj
@@ -18,6 +18,10 @@
     :test-selectors
     :managed-dependencies]
 
+   :project-selectors
+   {:deployable :deployable
+    :unstable #(= (first (:version %)) \0)}
+
    :project-dirs
    ["apps/app-a"
     "libs/*"

--- a/src/lein_monolith/config.clj
+++ b/src/lein_monolith/config.clj
@@ -113,3 +113,19 @@
     (map (juxt dep/project-name identity))
     (into {})
     (debug-profile "read-subprojects!")))
+
+
+
+;; ## Misc Configuration
+
+(defn get-selector
+  "Looks up the subproject selector from the configuration map. Aborts if a
+  selector is specified but does not exist."
+  [monolith selector-key]
+  (when selector-key
+    (let [selectors (get-in monolith [:monolith :project-selectors])
+          selector (get selectors selector-key)]
+      (when-not selector
+        (lein/abort (format "Project selector %s is not configured in %s"
+                            selector-key (keys selectors))))
+      (eval selector))))

--- a/src/leiningen/monolith.clj
+++ b/src/leiningen/monolith.clj
@@ -260,29 +260,41 @@
 
   Options:
     :subtree            Only iterate over transitive dependencies of the current project
+    :select <key>       Use a selector from the config to filter projects
     :start <project>    Provide a starting point for the subproject iteration
 
   Examples:
 
       lein monolith each check
       lein monolith each :subtree install
+      lein monolith each :select :deployable uberjar
       lein monolith each :start my/lib-a test"
   [project & args]
-  (let [[opts task] (parse-kw-args {:subtree 0, :start 1} args)]
+  (let [[opts task] (parse-kw-args {:subtree 0
+                                    :select 1
+                                    :start 1}
+                                   args)]
     (when (empty? task)
       (lein/abort "Cannot run each without task argument!"))
     (let [[monolith subprojects] (load-monolith! project)
+          selector (some->> (:select opts) ffirst read-string
+                            (config/get-selector monolith))
           start-from (some-> (:start opts) ffirst read-string)
-          relevant-subprojects (cond-> (dep/dependency-map subprojects)
-                                 (:subtree opts)
-                                 (dep/subtree-from (dep/project-name project)))
-          targets (-> relevant-subprojects
-                      (dep/topological-sort)
-                      (->> (map-indexed vector))
+          candidates (-> (dep/dependency-map subprojects)
+                         (cond->
+                           (:subtree opts)
+                             (dep/subtree-from (dep/project-name project)))
+                         (dep/topological-sort)
+                         (cond->>
+                           selector
+                             (filter (comp selector subprojects))))
+          targets (-> (map-indexed vector candidates)
                       (cond->>
                         start-from
                           (drop-while (comp (partial not= start-from) second))))
           start-time (System/nanoTime)]
+      (when (empty? targets)
+        (lein/abort "Iteration selection matched zero subprojects!"))
       (lein/info "Applying"
                  (ansi/sgr (str/join " " task) :bold :cyan)
                  "to" (ansi/sgr (count targets) :cyan)
@@ -293,7 +305,7 @@
             (lein/info (format "\nApplying to %s (%s/%s)"
                                (ansi/sgr subproject-name :bold :yellow)
                                (ansi/sgr (inc i) :cyan)
-                               (ansi/sgr (count relevant-subprojects) :cyan)))
+                               (ansi/sgr (count candidates) :cyan)))
             (as-> (get subprojects subproject-name) subproject
               (if-let [inherited (:monolith/inherit subproject)]
                 (assoc-in subproject [:profiles :monolith/inherited]


### PR DESCRIPTION
Fixes #7 #8 

This adds two new options to the `each` subtask:
- `:skip` lets you omit one or more projects from the iteration targets.
- `:select` uses a selector function from the metaproject to filter the iteration targets.

Conceptually, the `:select` config is very similar to `:test-selectors`. The value for each key is a function which runs on the subproject definition and should return a truthy value if the project should be included. Keywords provide a simple approach, but you can see in the example that more complex behavior is also possible.