### PR TITLE
Endure option in 'each' task

### DIFF
--- a/example/project.clj
+++ b/example/project.clj
@@ -2,7 +2,7 @@
   :description "Overarching example project."
 
   :plugins
-  [[lein-monolith "0.2.2-SNAPSHOT"]
+  [[lein-monolith "0.2.3-SNAPSHOT"]
    [lein-cprint "1.2.0"]]
 
   :dependencies


### PR DESCRIPTION
This option allows you to run the `each` task over all selected subprojects, even if there are failures on specific projects. The exit result will be success if no projects failed, or failure if any had an error.