### PR TITLE
Parallel each

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
 
   :dependencies
   [[manifold "0.1.5"]
-   [mvxcvi/puget "1.0.0"]
+   [mvxcvi/puget "1.0.1"]
    [rhizome "0.2.7"]]
 
   :profiles

--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,8 @@
   :eval-in-leiningen true
 
   :dependencies
-  [[mvxcvi/puget "1.0.0"]
+  [[manifold "0.1.5"]
+   [mvxcvi/puget "1.0.0"]
    [rhizome "0.2.7"]]
 
   :profiles

--- a/src/lein_monolith/task/each.clj
+++ b/src/lein_monolith/task/each.clj
@@ -116,7 +116,7 @@
       (apply-subproject-task (:monolith ctx) subproject (:task ctx))
       (assoc @results :success true)
       (catch Exception ex
-        (when-not (:parallel opts)
+        (when-not (or (:parallel opts) (:endure opts))
           (let [resume-args (concat
                               ["lein monolith each"]
                               (opts->args (dissoc opts :start))

--- a/src/lein_monolith/task/each.clj
+++ b/src/lein_monolith/task/each.clj
@@ -91,7 +91,7 @@
             [:default :monolith/inherited]
             [:default])))
       (config/debug-profile "apply-task"
-        (lein/apply-task (first task) subproject (rest task))))))
+        (lein/resolve-and-apply subproject task)))))
 
 
 (defn- run-task!

--- a/src/lein_monolith/task/each.clj
+++ b/src/lein_monolith/task/each.clj
@@ -165,7 +165,7 @@
   "Runs the task for each target in a linear (single-threaded) fashion. Returns
   a vector of result maps in the order the tasks were executed."
   [ctx targets]
-  (mapv (comp (partial apply run-task! ctx) second) targets))
+  (mapv (comp (partial run-task! ctx) second) targets))
 
 
 (defn- run-parallel!
@@ -218,7 +218,7 @@
                :num-targets n
                :task task
                :opts opts}
-          results (if-let [threads (read-string (ffirst (:parallel opts)))]
+          results (if-let [threads (some-> (:parallel opts) ffirst read-string)]
                     (run-parallel! ctx threads targets)
                     (run-linear! ctx targets))
           elapsed (/ (- (System/nanoTime) start-time) 1000000.0)]

--- a/src/lein_monolith/task/each.clj
+++ b/src/lein_monolith/task/each.clj
@@ -49,23 +49,23 @@
   [results elapsed]
   (let [task-time (reduce + (keep :elapsed results))
         speedup (/ task-time elapsed)]
-    (lein/info (format "\n%s  %7.3f seconds"
+    (lein/info (format "\n%s  %11s"
                        (ansi/sgr "Run time:" :bold :cyan)
-                       (/ elapsed 1000)))
-    (lein/info (format "%s %7.3f seconds"
+                       (u/human-duration elapsed)))
+    (lein/info (format "%s %11s"
                        (ansi/sgr "Task time:" :bold :cyan)
-                       (/ task-time 1000)))
-    (lein/info (format "%s   %7.1f"
+                       (u/human-duration task-time)))
+    (lein/info (format "%s   %11.1f"
                        (ansi/sgr "Speedup:" :bold :cyan)
                        speedup))
     (lein/info (->> results
                     (sort-by :elapsed)
                     (reverse)
                     (take 8)
-                    (map #(format "%-40s %s %.3f seconds"
+                    (map #(format "%-45s %s %11s"
                                   (ansi/sgr (:name %) :bold :yellow)
                                   (if (:success %) " " "!")
-                                  (/ (:elapsed %) 1000)))
+                                  (u/human-duration (:elapsed %))))
                     (str/join "\n")
                     (str \newline
                          (ansi/sgr "Slowest projects:" :bold :cyan)
@@ -218,15 +218,15 @@
       (when (:report opts)
         (print-report results elapsed))
       (if-let [failures (seq (map :name (remove :success results)))]
-        (lein/abort (format "\n%s: Applied %s to %s projects in %.3f seconds with %d failures: %s"
+        (lein/abort (format "\n%s: Applied %s to %s projects in %s with %d failures: %s"
                             (ansi/sgr "FAILURE" :bold :red)
                             (ansi/sgr (str/join " " task) :bold :cyan)
                             (ansi/sgr (count targets) :cyan)
-                            (/ elapsed 1000.0)
+                            (u/human-duration elapsed)
                             (count failures)
                             (str/join " " failures)))
-        (lein/info (format "\n%s: Applied %s to %s projects in %.3f seconds"
+        (lein/info (format "\n%s: Applied %s to %s projects in %s"
                            (ansi/sgr "SUCCESS" :bold :green)
                            (ansi/sgr (str/join " " task) :bold :cyan)
                            (ansi/sgr (count targets) :cyan)
-                           (/ elapsed 1000.0)))))))
+                           (u/human-duration elapsed)))))))

--- a/src/lein_monolith/task/each.clj
+++ b/src/lein_monolith/task/each.clj
@@ -15,6 +15,7 @@
 (def task-opts
   {:endure 0
    :subtree 0
+   :parallel 0
    :select 1
    :skip 1
    :start 1})
@@ -29,6 +30,8 @@
       [:endure])
     (when (:subtree opts)
       [:subtree])
+    (when (:parallel opts)
+      [:parallel])
     (when-let [selector (ffirst (:select opts))]
       [:select selector])
     (when-let [skips (seq (map first (:skip opts)))]

--- a/src/lein_monolith/task/each.clj
+++ b/src/lein_monolith/task/each.clj
@@ -204,6 +204,8 @@
         start-time (System/nanoTime)]
     (when (empty? targets)
       (lein/abort "Iteration selection matched zero subprojects!"))
+    (when (and (:start opts) (:parallel opts))
+      (lein/abort "The :parallel and :start options are not compatible"))
     (lein/info "Applying"
                (ansi/sgr (str/join " " task) :bold :cyan)
                "to" (ansi/sgr (count targets) :cyan)

--- a/src/lein_monolith/task/util.clj
+++ b/src/lein_monolith/task/util.clj
@@ -31,6 +31,23 @@
             (drop (inc arg-count) args))))))
 
 
+(defn human-duration
+  "Renders a duration in milliseconds in hour:minute:second.ms format."
+  [duration]
+  (if duration
+    (let [hours (int (/ duration 1000.0 60 60))
+          minutes (- (int (/ duration 1000.0 60))
+                     (* hours 60))
+          seconds (- (int (/ duration 1000.0))
+                     (* minutes 60)
+                     (* hours 60 60))
+          milliseconds (int (rem duration 1000))]
+      (if (pos? hours)
+        (format "%d:%02d:%02d.%03d" hours minutes seconds milliseconds)
+        (format "%d:%02d.%03d" minutes seconds milliseconds)))
+    "--:--"))
+
+
 (defn load-monolith!
   "Helper function to make a common pattern more succinct."
   [project]

--- a/src/leiningen/monolith.clj
+++ b/src/leiningen/monolith.clj
@@ -99,8 +99,8 @@
 
   Options:
     :subtree            Only iterate over transitive dependencies of the current project
-    :parallel           Run tasks in parallel (in dependency order)
     :report             Print a detailed timing report after running tasks
+    :parallel <threads> Run tasks in parallel across a fixed thread pool (in dependency order)
     :select <key>       Use a selector from the config to filter projects
     :skip <project>     Omit one or more projects from the iteration (may occur multiple times)
     :start <project>    Provide a starting point for the subproject iteration
@@ -108,9 +108,9 @@
   Examples:
 
       lein monolith each check
-      lein monolith each :subtree install
+      lein monolith each :subtree :parallel 4 install
       lein monolith each :select :deployable uberjar
-      lein monolith each :start my/lib-a test"
+      lein monolith each :report :start my/lib-a test"
   [project args]
   (let [[opts task] (u/parse-kw-args each/task-opts args)]
     (when (empty? task)

--- a/src/leiningen/monolith.clj
+++ b/src/leiningen/monolith.clj
@@ -100,6 +100,7 @@
   Options:
     :subtree            Only iterate over transitive dependencies of the current project
     :parallel           Run tasks in parallel (in dependency order)
+    :report             Print a detailed timing report after running tasks
     :select <key>       Use a selector from the config to filter projects
     :skip <project>     Omit one or more projects from the iteration (may occur multiple times)
     :start <project>    Provide a starting point for the subproject iteration

--- a/src/leiningen/monolith.clj
+++ b/src/leiningen/monolith.clj
@@ -99,6 +99,7 @@
 
   Options:
     :subtree            Only iterate over transitive dependencies of the current project
+    :parallel           Run tasks in parallel (in dependency order)
     :select <key>       Use a selector from the config to filter projects
     :skip <project>     Omit one or more projects from the iteration (may occur multiple times)
     :start <project>    Provide a starting point for the subproject iteration


### PR DESCRIPTION
These changes add two new options to the `each` task, `:report` and `:parallel`. The first prints out a data structure at the end of the run with timing and error info for each subproject. The second runs tasks in parallel according to the graph of dependencies between the subprojects in the repo.

This means if you have projects `A`, `B`, `C`, and `D` where `B -> A`, `C -> A`, `D -> B`, and `D -> C`, then with `:parallel` the tasks for `B` and `C` will run concurrently after `A` finishes, and `D` will run once both `B` and `C` complete.

Running in different threads this way turns out to be slower _per task_ than if the tasks were all run in the same thread, for reasons I don't yet understand. However, spreading the tasks across all the available cores still results in a substantial speedup overall. Here are some rough timing comparisons on my laptop:

Timing of `lein monolith each install` in `amperity/app` with current `lein-monolith` version `0.2.3`:
```
SUCCESS: Applied install to 79 projects in 274.426 seconds
 Elapsed: 4:37.06 User: 437.83s Kernel: 15.783
```

Code from this PR without parallelization:
```
Total task time: 253.605 seconds
SUCCESS: Applied install to 79 projects in 265.569 seconds
 Elapsed: 4:28.41 User: 430.23s Kernel: 15.004
```

Parallel each!
```
Total task time: 1074.570 seconds
SUCCESS: Applied install to 79 projects in 136.618 seconds
 Elapsed: 2:19.61 User: 688.73s Kernel: 33.171
```

Same measurements, but running the CI unit tests:
```
FAILURE: Applied test :default to 36 projects in 293.915 seconds with 1 failures: amperity/flow
 Elapsed: 4:56.70 User: 399.17s Kernel: 18.904
```
```
Total task time: 313.472 seconds
FAILURE: Applied test :default to 36 projects in 318.272 seconds with 1 failures: amperity/flow
 Elapsed: 5:21.48 User: 419.17s Kernel: 22.789
```
```
Total task time: 636.904 seconds
FAILURE: Applied test :default to 36 projects in 133.898 seconds with 2 failures: amperity/indexing amperity/flow
 Elapsed: 2:17.26 User: 619.87s Kernel: 38.883
```

So, a speedup of a bit more than 2x by running tasks in parallel!