### PR TITLE
Use an environment variable to set the number of threads

### DIFF
--- a/src/lein_monolith/task/each.clj
+++ b/src/lein_monolith/task/each.clj
@@ -33,7 +33,8 @@
       [:endure])
     (when (:subtree opts)
       [:subtree])
-    (when-let [threads (ffirst (:parallel opts))]
+    (when-let [threads (or (ffirst (:parallel opts))
+                           (System/getProperty "MONOLITH_CPU_COUNT"))]
       [:parallel threads])
     (when (:report opts)
       [:report])


### PR DESCRIPTION
Instead of explicitly passing number of threads, use an environment variable to set its value if no value is provided for `:parallel`. The name of the environment variable is `MONOLITH_CPU_COUNT`.
