### PR TITLE
Dependency closure selection

### DIFF
--- a/example/libs/lib-a/project.clj
+++ b/example/libs/lib-a/project.clj
@@ -1,5 +1,8 @@
 (defproject example/lib-a "1.0.0"
   :description "Example library with no internal dependencies."
+  :monolith/inherit true
+
+  :pedantic? :abort
 
   :dependencies
   [[org.clojure/clojure "1.8.0"]])

--- a/example/project.clj
+++ b/example/project.clj
@@ -2,7 +2,7 @@
   :description "Overarching example project."
 
   :plugins
-  [[lein-monolith "0.3.0"]
+  [[lein-monolith "0.3.1-SNAPSHOT"]
    [lein-cprint "1.2.0"]]
 
   :dependencies

--- a/project.clj
+++ b/project.clj
@@ -13,6 +13,12 @@
    [mvxcvi/puget "1.0.1"]
    [rhizome "0.2.7"]]
 
+  :hiera
+  {:vertical false
+   :show-external true
+   :cluster-depth 1
+   :ignore-ns #{clojure puget manifold}}
+
   :profiles
   {:dev {:plugins [[rfkm/lein-cloverage "1.0.8"]]
          :dependencies [[org.clojure/clojure "1.8.0"]]}})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-monolith "0.3.0"
+(defproject lein-monolith "0.3.1-SNAPSHOT"
   :description "Leiningen plugin for managing subrojects within a monorepo."
   :url "https://github.com/amperity/lein-monolith"
   :license {:name "Apache License 2.0"

--- a/src/lein_monolith/config.clj
+++ b/src/lein_monolith/config.clj
@@ -113,19 +113,3 @@
     (map (juxt dep/project-name identity))
     (into {})
     (debug-profile "read-subprojects!")))
-
-
-
-;; ## Misc Configuration
-
-(defn get-selector
-  "Looks up the subproject selector from the configuration map. Aborts if a
-  selector is specified but does not exist."
-  [monolith selector-key]
-  (when selector-key
-    (let [selectors (get-in monolith [:monolith :project-selectors])
-          selector (get selectors selector-key)]
-      (when-not selector
-        (lein/abort (format "Project selector %s is not configured in %s"
-                            selector-key (keys selectors))))
-      (eval selector))))

--- a/src/lein_monolith/dependency.clj
+++ b/src/lein_monolith/dependency.clj
@@ -27,6 +27,21 @@
     (condense-name (symbol (:group project) (:name project)))))
 
 
+(defn resolve-name
+  "Given a set of valid project names, determine the match for the named
+  project. This can be used to resolve the short name (meaning, no namespace)
+  to a fully-qualified project name. Returns a resolved key from
+  `project-names`, or nil if the resolution fails."
+  [project-names sym]
+  (let [valid-keys (set project-names)]
+    (cond
+      (valid-keys sym) sym
+      (valid-keys (condense-name sym)) (condense-name sym)
+      (nil? (namespace sym))
+        (first (filter #(= (name %) (name sym)) valid-keys))
+      :else nil)))
+
+
 (defn unscope-coord
   "Removes the `:scope` entry from a leiningen dependency coordinate vector,
   if it is present. Preserves any metadata on the coordinate."

--- a/src/lein_monolith/dependency.clj
+++ b/src/lein_monolith/dependency.clj
@@ -129,18 +129,20 @@
 
 (defn topological-sort
   "Returns a sequence of the keys in the map `m`, ordered such that no key `k1`
-  appearing before `k2` satisfies `(contains? (get m k1) k2)`. In other words,
-  earlier keys do not 'depend on' later keys."
-  [m]
-  (when (seq m)
-    ; Note that 'roots' here are keys which no other keys depend on, hence
-    ; should appear *later* in the sequence.
-    (let [roots (apply set/difference (set (keys m)) (map set (vals m)))]
-      (when (empty? roots)
-        (throw (ex-info "Cannot sort the keys in the given map, cycle detected!"
-                        {:input m})))
-      (concat (topological-sort (apply dissoc m roots))
-              (sort roots)))))
+  appearing before `k2` satisfies `(contains? (upstream-keys m k1) k2)`. In
+  other words, earlier keys do not transitively depend on any later keys."
+  ([m]
+   (when (seq m)
+     ; Note that 'roots' here are keys which no other keys depend on, hence
+     ; should appear *later* in the sequence.
+     (let [roots (apply set/difference (set (keys m)) (map set (vals m)))]
+       (when (empty? roots)
+         (throw (ex-info "Cannot sort the keys in the given map, cycle detected!"
+                         {:input m})))
+       (concat (topological-sort (apply dissoc m roots))
+               (sort roots)))))
+  ([m ks]
+   (filter (set ks) (topological-sort m))))
 
 
 ; TODO: deprecate this

--- a/src/lein_monolith/dependency.clj
+++ b/src/lein_monolith/dependency.clj
@@ -145,30 +145,6 @@
    (filter (set ks) (topological-sort m))))
 
 
-; TODO: deprecate this
-(defn subtree-from
-  "Takes a map of node keys to sets of dependent nodes and a root node to start
-  from. Returns the same dependency map containing only keys in the transitive
-  subtree of the root."
-  [m root]
-  (loop [result {}
-         front [root]]
-    (if-let [node (first front)]
-      (if (contains? m node)
-        ; Node is part of the internal tree.
-        (let [deps (set (get m node))
-              new-front (set/difference deps (set (keys result)))]
-          (recur
-            ; Add the node to the result map.
-            (assoc result node deps)
-            ; Add any unprocessed dependencies to the front.
-            (concat (next front) (set/difference deps (set (keys result))))))
-        ; Node is not internal, so ignore.
-        (recur result (next front)))
-      ; No more nodes to process.
-      result)))
-
-
 
 ;; ## Dependency Resolution
 

--- a/src/lein_monolith/dependency.clj
+++ b/src/lein_monolith/dependency.clj
@@ -56,7 +56,7 @@
 
 (defn dependency-map
   "Converts a map of project names to definitions into a map of project names
-  to sets of project-names that node depends on."
+  to sets of projects that node depends on."
   [projects]
   (->>
     (vals projects)
@@ -142,22 +142,3 @@
                              (str/join " " (sort projects)))))
         (lein/warn "")
         default-choice))))
-
-
-(defn dedupe-dependencies
-  "Given a vector of dependency coordinates, deduplicate and ensure there are no
-  conflicting versions found."
-  [dependencies]
-  (let [error-flag (atom false)
-        chosen-deps
-        (reduce-kv
-          (fn [current dep-name specs]
-            (if-let [choice (select-dependency dep-name specs)]
-              (conj current choice)
-              (do (reset! error-flag true)
-                  current)))
-          []
-          (group-by first dependencies))]
-    (when @error-flag
-      (lein/abort "Unresolvable dependency conflicts!"))
-    chosen-deps))

--- a/src/lein_monolith/target.clj
+++ b/src/lein_monolith/target.clj
@@ -49,7 +49,7 @@
   projects to produce a final sequence of projects."
   [subprojects selector targets]
   (->>
-    targets
+    (sort targets)
     (map-indexed (fn [i p] [p (assoc (subprojects p) :monolith/index i)]))
     (filter (comp selector second))
     (map first)))

--- a/src/lein_monolith/target.clj
+++ b/src/lein_monolith/target.clj
@@ -25,7 +25,7 @@
     (seq name-args)
     (mapcat #(str/split % #"\s*,\s*"))
     (map read-string)
-    (keep (partial dep/resolve-name (keys subprojects)))
+    (map (partial dep/resolve-name! (keys subprojects)))
     (set)))
 
 

--- a/src/lein_monolith/target.clj
+++ b/src/lein_monolith/target.clj
@@ -3,9 +3,8 @@
   (:require
     [clojure.set :as set]
     [clojure.string :as str]
-    (lein-monolith
-      [config :as config]
-      [dependency :as dep])))
+    [lein-monolith.dependency :as dep]
+    [leiningen.core.main :as lein]))
 
 
 (def selection-opts

--- a/src/lein_monolith/target.clj
+++ b/src/lein_monolith/target.clj
@@ -1,0 +1,83 @@
+(ns lein-monolith.target
+  "Functions for constructing and operating on dependency closures."
+  (:require
+    [clojure.set :as set]
+    [clojure.string :as str]
+    (lein-monolith
+      [config :as config]
+      [dependency :as dep])))
+
+
+(def selection-opts
+  {:in* 1
+   :upstream 0
+   :upstream-of* 1
+   :downstream 0
+   :downstream-of* 1
+   :skip* 1
+   :select* 1})
+
+
+(defn- resolve-projects
+  "Returns a set of project names that have been resolved from the given
+  sequence, which may consist of multiple comma-separated lists. Ignores names
+  which do not map to a project."
+  [subprojects name-args]
+  (some->>
+    (seq name-args)
+    (mapcat #(str/split % #"\s*,\s*"))
+    (map read-string)
+    (keep (partial dep/resolve-name (keys subprojects)))
+    (set)))
+
+
+(defn- resolve-selectors
+  "Returns a selection function to filter projects based on the `:select`
+  options passed. Multiple selection functions apply cumulative layers of
+  filtering, meaning a project must pass _every_ selector to be included.
+  Returns nil if no selectors were specified."
+  [monolith select-args]
+  (some->>
+    (seq select-args)
+    (map read-string)
+    (map (partial config/get-selector monolith))
+    (apply every-pred)))
+
+
+(defn- filter-selected
+  "Applies a project-selector function to the topologically-sorted set of
+  projects to produce a final sequence of projects."
+  [subprojects selector targets]
+  (->>
+    targets
+    (map-indexed (fn [i p] [p (assoc (subprojects p) :monolith/index i)]))
+    (filter (comp selector second))
+    (map first)))
+
+
+(defn select-targets
+  "Returns a set of canonical project names selected by the given options."
+  [monolith subprojects project-name opts]
+  (let [dependencies (dep/dependency-map subprojects)
+        upstream-of (cond-> (resolve-projects subprojects (:upstream-of opts)
+                      (:upstream opts) (conj project-name)))
+        downstream-of (cond-> (resolve-projects subprojects (:downstream-of opts)
+                        (:downstream opts) (conj project-name)))
+        skippable (resolve-projects subprojects (:skip opts))
+        selector (resolve-selectors (:select opts))]
+    (->
+      ; Start with explicitly-specified 'in' targets.
+      (resolve-projects subprojects (:in opts))
+      (as-> targets
+        ; Merge all targeted upstream dependencies.
+        (reduce set/union targets (map (partial dep/upstream-keys dependencies) upstream-of))
+        ; Merge all targeted downstream dependencies.
+        (reduce set/union targets (map (partial dep/downstream-keys dependencies) downstream-of))
+        ; If target set empty, replace with full set.
+        (if (empty? targets) (set (keys subprojects)) targets)
+        ; Exclude all 'skip' targets.
+        (remove skippable targets))
+      (cond->>
+        ; Filter using the selector, if any.
+        selector (filter-selected subprojects selector))
+      (set))))

--- a/src/lein_monolith/task/checkouts.clj
+++ b/src/lein_monolith/task/checkouts.clj
@@ -63,7 +63,7 @@
         projects-to-link (as-> (:dependencies project) deps
                            (map (comp dep/condense-name first) deps)
                            (if (:deep opts)
-                             (set (mapcat (comp keys (partial dep/subtree-from dep-map)) deps))
+                             (set (mapcat (partial dep/upstream-keys dep-map) deps))
                              deps)
                            (keep subprojects deps))
         checkouts-dir (io/file (:root project) "checkouts")]

--- a/src/lein_monolith/task/checkouts.clj
+++ b/src/lein_monolith/task/checkouts.clj
@@ -1,6 +1,7 @@
 (ns lein-monolith.task.checkouts
   (:require
     [clojure.java.io :as io]
+    [clojure.string :as str]
     [leiningen.core.main :as lein]
     [lein-monolith.dependency :as dep]
     [lein-monolith.task.util :as u])
@@ -56,9 +57,8 @@
 (defn link
   "Create symlinks in the checkouts directory pointing to all internal
   dependencies in the current project."
-  [project args]
-  (let [[opts _] (u/parse-kw-args {:force 0, :deep 0} args)
-        [monolith subprojects] (u/load-monolith! project)
+  [project opts]
+  (let [[monolith subprojects] (u/load-monolith! project)
         dep-map (dep/dependency-map subprojects)
         projects-to-link (as-> (:dependencies project) deps
                            (map (comp dep/condense-name first) deps)

--- a/src/lein_monolith/task/checkouts.clj
+++ b/src/lein_monolith/task/checkouts.clj
@@ -57,7 +57,7 @@
   "Create symlinks in the checkouts directory pointing to all internal
   dependencies in the current project."
   [project args]
-  (let [[opts _] (u/parse-kw-args {:force 0 :deep 0} args)
+  (let [[opts _] (u/parse-kw-args {:force 0, :deep 0} args)
         [monolith subprojects] (u/load-monolith! project)
         dep-map (dep/dependency-map subprojects)
         projects-to-link (as-> (:dependencies project) deps

--- a/src/lein_monolith/task/each.clj
+++ b/src/lein_monolith/task/each.clj
@@ -214,7 +214,7 @@
                :task task
                :opts opts}
           results (if-let [threads (:parallel opts)]
-                    (run-parallel! ctx threads targets)
+                    (run-parallel! ctx (Integer/parseInt threads) targets)
                     (run-linear! ctx targets))
           elapsed (/ (- (System/nanoTime) start-time) 1000000.0)]
       (when (:report opts)

--- a/src/lein_monolith/task/each.clj
+++ b/src/lein_monolith/task/each.clj
@@ -82,7 +82,7 @@
         skippable (some->> (:skip opts) (map (comp read-string first)) set)
         start-from (some-> (:start opts) ffirst read-string)]
     (->
-      ; Convert subproject map into {project-sym [dep-syms]} map
+      ; Convert subproject map into {project-sym #{dep-syms}} map
       (dep/dependency-map subprojects)
       (cond->
         ; If subtree is set, prune dependency map down to transitive dep

--- a/src/lein_monolith/task/each.clj
+++ b/src/lein_monolith/task/each.clj
@@ -94,7 +94,9 @@
                 (:downstream opts)
                   (update :downstream-of conj (str project-name)))
         targets (target/select monolith subprojects opts')
-        start-from (some-> (:start opts) read-string)]
+        start-from (some->> (:start opts)
+                            (read-string)
+                            (dep/resolve-name! (keys subprojects)))]
     (->
       ; Sort project names by dependency order.
       (dep/topological-sort dependencies targets)
@@ -202,7 +204,7 @@
         n (inc (or (first (last targets)) -1))
         start-time (System/nanoTime)]
     (when (empty? targets)
-      (lein/abort "Iteration selection matched zero subprojects!"))
+      (lein/abort "Target selection matched zero subprojects!"))
     (lein/info "Applying"
                (ansi/sgr (str/join " " task) :bold :cyan)
                "to" (ansi/sgr (count targets) :cyan)

--- a/src/lein_monolith/task/each.clj
+++ b/src/lein_monolith/task/each.clj
@@ -20,7 +20,7 @@
    :parallel 1
    :report 0
    :select 1
-   :skip 1
+   :skip* 1
    :start 1})
 
 
@@ -33,15 +33,15 @@
       [:endure])
     (when (:subtree opts)
       [:subtree])
-    (when-let [threads (ffirst (:parallel opts))]
+    (when-let [threads (:parallel opts)]
       [:parallel threads])
     (when (:report opts)
       [:report])
-    (when-let [selector (ffirst (:select opts))]
+    (when-let [selector (:select opts)]
       [:select selector])
-    (when-let [skips (seq (map first (:skip opts)))]
+    (when-let [skips (seq (:skip opts))]
       (mapcat (partial vector :skip) skips))
-    (when-let [start (ffirst (:start opts))]
+    (when-let [start (:start opts)]
       [:start start])))
 
 
@@ -77,10 +77,10 @@
   "Returns a vector of pairs of index numbers and symbols naming the selected
   subprojects."
   [monolith subprojects project-name opts]
-  (let [selector (some->> (:select opts) ffirst read-string
+  (let [selector (some->> (:select opts) read-string
                           (config/get-selector monolith))
-        skippable (some->> (:skip opts) (map (comp read-string first)) set)
-        start-from (some-> (:start opts) ffirst read-string)]
+        skippable (some->> (:skip opts) (map read-string) set)
+        start-from (some-> (:start opts) read-string)]
     (->
       ; Convert subproject map into {project-sym #{dep-syms}} map
       (dep/dependency-map subprojects)

--- a/src/lein_monolith/task/each.clj
+++ b/src/lein_monolith/task/each.clj
@@ -7,7 +7,8 @@
     (lein-monolith
       [config :as config]
       [dependency :as dep]
-      [plugin :as plugin])
+      [plugin :as plugin]
+      [target :as target])
     [lein-monolith.task.util :as u]
     [manifold.deferred :as d]
     [manifold.executor :as executor]
@@ -15,13 +16,15 @@
 
 
 (def task-opts
-  {:endure 0
-   :subtree 0
-   :parallel 1
-   :report 0
-   :select 1
-   :skip* 1
-   :start 1})
+  (merge
+    target/selection-opts
+    {:parallel 1
+     :endure 0
+     :report 0
+     :subtree 0 ; deprecated in favor of :upstream
+     :upstream 0
+     :downstream 0
+     :start 1}))
 
 
 (defn- opts->args
@@ -29,18 +32,26 @@
   a sequence of keywords and strings."
   [opts]
   (concat
-    (when (:endure opts)
-      [:endure])
-    (when (:subtree opts)
-      [:subtree])
     (when-let [threads (:parallel opts)]
       [:parallel threads])
+    (when (:endure opts)
+      [:endure])
     (when (:report opts)
       [:report])
-    (when-let [selector (:select opts)]
-      [:select selector])
+    (when-let [in (seq (:in opts))]
+      [:in (str/join "," in)])
+    (when (or (:subtree opts) (:upstream opts))
+      [:upstream])
+    (when-let [uof (seq (:upstream-of opts))]
+      [:upstream-of (str/join "," uof)])
+    (when (:downstream opts)
+      [:downstream])
+    (when-let [dof (seq (:downstream-of opts))]
+      [:downstream-of (str/join "," dof)])
+    (when-let [selectors (seq (:select opts))]
+      (mapcat (partial vector :select) selectors))
     (when-let [skips (seq (:skip opts))]
-      (mapcat (partial vector :skip) skips))
+      [:skip (str/join "," skips)])
     (when-let [start (:start opts)]
       [:start start])))
 
@@ -77,34 +88,23 @@
   "Returns a vector of pairs of index numbers and symbols naming the selected
   subprojects."
   [monolith subprojects project-name opts]
-  (let [selector (some->> (:select opts) read-string
-                          (config/get-selector monolith))
-        skippable (some->> (:skip opts) (map read-string) set)
+  (when (:subtree opts)
+    (lein/warn "The :subtree option is deprecated, use :upstream instead"))
+  (let [dependencies (dep/dependency-map subprojects)
+        opts' (cond-> opts
+                (or (:subtree opts) (:upstream opts))
+                  (update :upstream-of conj (str project-name))
+                (:downstream opts)
+                  (update :downstream-of conj (str project-name)))
+        targets (target/select monolith subprojects opts')
         start-from (some-> (:start opts) read-string)]
     (->
-      ; Convert subproject map into {project-sym #{dep-syms}} map
-      (dep/dependency-map subprojects)
-      (cond->
-        ; If subtree is set, prune dependency map down to transitive dep
-        ; closure of the current project.
-        (:subtree opts) (dep/subtree-from project-name))
-      ; Sort project names by dependency order into [project-sym ...]
-      (dep/topological-sort)
-      (cond->>
-        ; Remove the set of project names to skip, if any.
-        skippable (remove skippable))
-      (cond->
-        ; If selector is present, filter candidates by providing the project
-        ; map with an extra index key for selection logic.
-        selector (->> (map-indexed (fn [i p] [p (assoc (subprojects p) :monolith/index i)]))
-                      (filter (comp selector second))
-                      (map first)))
-      (->>
-        ; Pair each selected project name up with an index [[i project-sym] ...]
-        (map-indexed vector))
-      (cond->>
-        ; Skip projects until the starting project, if provided.
-        start-from (drop-while (comp (partial not= start-from) second))))))
+      ; Sort project names by dependency order.
+      (dep/topological-sort dependencies targets)
+      ; Skip projects until the starting project, if provided.
+      (cond->> start-from (drop-while (partial not= start-from)))
+      ; Pair names up with an index [[i project-sym] ...]
+      (->> (map-indexed vector)))))
 
 
 (defn- apply-subproject-task

--- a/src/lein_monolith/task/info.clj
+++ b/src/lein_monolith/task/info.clj
@@ -60,7 +60,7 @@
   [project opts project-names]
   (let [[monolith subprojects] (u/load-monolith! project)
         dep-map (dep/dependency-map subprojects)
-        resolved-names (map (partial dep/resolve-name (keys dep-map))
+        resolved-names (map (partial dep/resolve-name! (keys dep-map))
                             project-names)]
     (doseq [dep-name resolved-names]
       (when-not (:bare opts)
@@ -80,7 +80,7 @@
   [project opts project-names]
   (let [[monolith subprojects] (u/load-monolith! project)
         dep-map (dep/dependency-map subprojects)
-        resolved-names (map (partial dep/resolve-name (keys dep-map))
+        resolved-names (map (partial dep/resolve-name! (keys dep-map))
                             project-names)]
     (doseq [project-name resolved-names]
       (when-not (get dep-map project-name)

--- a/src/lein_monolith/task/info.clj
+++ b/src/lein_monolith/task/info.clj
@@ -59,8 +59,10 @@
   to the current project if none are provided."
   [project opts project-names]
   (let [[monolith subprojects] (u/load-monolith! project)
-        dep-map (dep/dependency-map subprojects)]
-    (doseq [dep-name project-names]
+        dep-map (dep/dependency-map subprojects)
+        resolved-names (map (partial dep/resolve-name (keys dep-map))
+                            project-names)]
+    (doseq [dep-name resolved-names]
       (when-not (:bare opts)
         (lein/info "\nSubprojects which depend on" (ansi/sgr dep-name :bold :yellow)))
       (doseq [subproject-name (dep/topological-sort dep-map)
@@ -77,8 +79,10 @@
   the current project if none are provided."
   [project opts project-names]
   (let [[monolith subprojects] (u/load-monolith! project)
-        dep-map (dep/dependency-map subprojects)]
-    (doseq [project-name project-names]
+        dep-map (dep/dependency-map subprojects)
+        resolved-names (map (partial dep/resolve-name (keys dep-map))
+                            project-names)]
+    (doseq [project-name resolved-names]
       (when-not (get dep-map project-name)
         (lein/abort project-name "is not a valid subproject!"))
       (when-not (:bare opts)

--- a/src/lein_monolith/task/info.clj
+++ b/src/lein_monolith/task/info.clj
@@ -1,5 +1,6 @@
 (ns lein-monolith.task.info
   (:require
+    [clojure.string :as str]
     [leiningen.core.main :as lein]
     (lein-monolith
       [config :as config]
@@ -13,8 +14,10 @@
 (defn info
   "Show information about the monorepo configuration."
   [project args]
-  (let [[opts _] (u/parse-kw-args (merge target/selection-opts {:bare 0}) args)
+  (let [[opts args] (u/parse-kw-args (merge target/selection-opts {:bare 0}) args)
         monolith (config/find-monolith! project)]
+    (when (seq args)
+      (lein/abort "Unknown args:" (str/join " " args)))
     (when-not (:bare opts)
       (println "Monolith root:" (:root monolith))
       (println)

--- a/src/lein_monolith/task/info.clj
+++ b/src/lein_monolith/task/info.clj
@@ -97,12 +97,10 @@
                      "transitively depends on"
                      "depends on")))
       (doseq [dep (if (:transitive opts)
-                    (-> (dep/subtree-from dep-map project-name)
-                        (dissoc project-name)
-                        (dep/topological-sort))
-                    (->> (get-in subprojects [project-name :dependencies])
-                         (map first)
-                         (filter subprojects)))]
+                    (-> (dep/upstream-keys dep-map project-name)
+                        (disj project-name)
+                        (->> (dep/topological-sort dep-map)))
+                    (dep-map project-name))]
         (if (:bare opts)
           (println project-name dep)
           (println "  " (puget/cprint-str project-name)

--- a/src/lein_monolith/task/info.clj
+++ b/src/lein_monolith/task/info.clj
@@ -28,7 +28,7 @@
         (println)))
     (let [subprojects (config/read-subprojects! monolith)
           dependencies (dep/dependency-map subprojects)
-          targets (target/select monolith subprojects (dep/project-name project) opts)
+          targets (target/select monolith subprojects opts)
           prefix-len (inc (count (:root monolith)))]
       (when-not (:bare opts)
         (printf "Internal projects (%d):\n" (count targets)))

--- a/src/leiningen/monolith.clj
+++ b/src/leiningen/monolith.clj
@@ -155,9 +155,11 @@
     (when (empty? task)
       (lein/abort "Cannot run each without a task argument!"))
     (when (and (:start opts) (:parallel opts))
-      (lein/abort "The :parallel and :start options are not compatible"))
+      (lein/abort "The :parallel and :start options are not compatible!"))
+    (when (and (:monolith project) (or (:upstream opts) (:downstream opts)))
+      (lein/warn "The :upstream and :downstream options have no meaning in the monolith project."))
     (when (:subtree opts)
-      (lein/warn "The :subtree option is deprecated, use :upstream instead"))
+      (lein/warn "The :subtree option is deprecated, use :upstream instead."))
     (each/run-tasks project opts task)))
 
 

--- a/src/leiningen/monolith.clj
+++ b/src/leiningen/monolith.clj
@@ -56,7 +56,7 @@
   Options:
     :deps        Check for conflicting dependency versions"
   [project args]
-  (info/lint project (opts-only {:deps 0} args)))
+  (info/lint project (if (seq args) (opts-only {:deps 0} args) {:deps true})))
 
 
 (defn deps-on

--- a/src/leiningen/monolith.clj
+++ b/src/leiningen/monolith.clj
@@ -145,13 +145,19 @@
   Examples:
 
       lein monolith each check
-      lein monolith each :subtree :parallel 4 install
+      lein monolith each :upstream :parallel 4 install
       lein monolith each :select :deployable uberjar
       lein monolith each :report :start my/lib-a test"
   [project args]
-  (let [[opts task] (u/parse-kw-args each/task-opts args)]
+  (let [expected (assoc each/task-opts :subtree 0)
+        [opts task] (u/parse-kw-args each/task-opts args)
+        opts (cond-> opts (:subtree opts) (assoc :upstream true))]
     (when (empty? task)
       (lein/abort "Cannot run each without a task argument!"))
+    (when (and (:start opts) (:parallel opts))
+      (lein/abort "The :parallel and :start options are not compatible"))
+    (when (:subtree opts)
+      (lein/warn "The :subtree option is deprecated, use :upstream instead"))
     (each/run-tasks project opts task)))
 
 

--- a/src/leiningen/monolith.clj
+++ b/src/leiningen/monolith.clj
@@ -89,21 +89,38 @@
 
 
 (defn ^:higher-order each
-  "Iterate over each subproject in the monolith and apply the given task.
-  Projects are iterated in dependency order; that is, later projects may depend
-  on earlier ones.
+  "Iterate over a target set of subprojects in the monolith and apply the given
+  task. Projects are iterated in dependency order; that is, later projects may
+  depend on earlier ones.
+
+  By default, all projects are included in the set of iteration targets. If you
+  provide the `:in`, `:upstream[-of]`, or `:downstream[-of]` options then the
+  resulting set of projects will be composed only of the additive targets of
+  each of the options specified. The `:skip` option can be used to exclude
+  specific projects from the set. Specifying `:select` will use a configured
+  `:project-selector` to filter the final set.
 
   If the iteration fails on a subproject, you can continue where you left off
   by providing the `:start` option as the first argument, giving the name of the
   project to resume from.
 
-  Options:
-    :subtree            Only iterate over transitive dependencies of the current project
-    :report             Print a detailed timing report after running tasks
-    :parallel <threads> Run tasks in parallel across a fixed thread pool (in dependency order)
-    :select <key>       Use a selector from the config to filter projects
-    :skip <project>     Omit one or more projects from the iteration (may occur multiple times)
-    :start <project>    Provide a starting point for the subproject iteration
+  General Options:
+    :parallel <threads>        Run tasks in parallel across a fixed thread pool.
+    :endure                    Continue executing the task even if some subprojects fail.
+    :report                    Print a detailed timing report after running tasks.
+
+  Targeting Options:
+    :in <names>             Add the named projects directly to the targets.
+    :upstream               Add the transitive dependencies of the current project to the targets.
+    :upstream-of <names>    Add the transitive dependencies of the named projects to the targets.
+    :downstream             Add the transitive consumers of the current project to the targets.
+    :downstream-of <names>  Add the transitive consumers of the named projects to the targets.
+    :select <key>           Use a selector from the config to filter target projects.
+    :skip <names>           Exclude one or more projects from the target set.
+    :start <names>          Provide a starting point for the subproject iteration
+
+  Each <names> argument can contain multiple comma-separated project names, and
+  all the targeting options except `:start` may be provided multiple times.
 
   Examples:
 

--- a/src/leiningen/monolith.clj
+++ b/src/leiningen/monolith.clj
@@ -137,7 +137,7 @@
     :downstream-of <names>  Add the transitive consumers of the named projects to the targets.
     :select <key>           Use a selector from the config to filter target projects.
     :skip <names>           Exclude one or more projects from the target set.
-    :start <names>          Provide a starting point for the subproject iteration
+    :start <name>           Provide a starting point for the subproject iteration
 
   Each <names> argument can contain multiple comma-separated project names, and
   all the targeting options except `:start` may be provided multiple times.

--- a/test/example-tests.sh
+++ b/test/example-tests.sh
@@ -26,8 +26,12 @@ test_monolith() {
 }
 
 test_monolith info
+test_monolith lint
 test_monolith deps-of example/app-a
 test_monolith deps-on example/lib-a
-test_monolith each cprint :version
 test_monolith with-all cprint :dependencies :source-paths
-test_monolith lint
+test_monolith each cprint :version
+test_monolith each :in lib-a cprint :root
+test_monolith each :upstream-of lib-b cprint :version
+test_monolith each :downstream-of lib-a cprint :name
+test_monolith each :parallel 3 :report :endure check

--- a/test/example-tests.sh
+++ b/test/example-tests.sh
@@ -34,4 +34,4 @@ test_monolith each cprint :version
 test_monolith each :in lib-a cprint :root
 test_monolith each :upstream-of lib-b cprint :version
 test_monolith each :downstream-of lib-a cprint :name
-test_monolith each :parallel 3 :report :endure check
+test_monolith each :parallel 3 :report :endure cprint :group

--- a/test/lein_monolith/dependency_test.clj
+++ b/test/lein_monolith/dependency_test.clj
@@ -17,6 +17,7 @@
     (let [projects '[foo baz/foo example/bar example/baz]]
       (is (nil? (dep/resolve-name projects 'qux)))
       (is (nil? (dep/resolve-name projects 'example/qux)))
+      (is (= '[foo/baz bar/baz] (dep/resolve-name '[foo/baz bar/baz bar/qux] 'baz)))
       (is (= 'foo (dep/resolve-name projects 'foo)))
       (is (= 'foo (dep/resolve-name projects 'foo/foo)))
       (is (= 'example/bar (dep/resolve-name projects 'bar)))

--- a/test/lein_monolith/dependency_test.clj
+++ b/test/lein_monolith/dependency_test.clj
@@ -35,19 +35,6 @@
     (is (= 'example/bar (dep/dep-source (dep/with-source [:foo "123"] 'example/bar))))))
 
 
-(deftest subtree-resolution
-  (is (= {}
-         (dep/subtree-from {} nil)))
-  (is (= {}
-         (dep/subtree-from {:a [], :b [:a]} nil)))
-  (is (= {:a #{}}
-         (dep/subtree-from {:a [], :b [:a]} :a)))
-  (is (= {:a #{}, :b #{:a}}
-         (dep/subtree-from {:a [], :b [:a], :c [:a]} :b)))
-  (is (= {:a #{}, :b #{:a :x}}
-         (dep/subtree-from {:a [], :b [:a :x], :c [:a]} :b))))
-
-
 (deftest upstream-dependency-closure
   (let [deps {:a #{}, :b #{:a}, :c #{:a :b} :x #{:b} :y #{:c}}]
     (is (= #{:a} (dep/upstream-keys deps :a)))

--- a/test/lein_monolith/dependency_test.clj
+++ b/test/lein_monolith/dependency_test.clj
@@ -13,6 +13,14 @@
     (is (nil? (dep/project-name nil)))
     (is (= 'foo (dep/project-name {:group "foo", :name "foo"})))
     (is (= 'example/bar (dep/project-name {:group "example", :name "bar"}))))
+  (testing "resolve-name"
+    (let [projects '[foo baz/foo example/bar example/baz]]
+      (is (nil? (dep/resolve-name projects 'qux)))
+      (is (nil? (dep/resolve-name projects 'example/qux)))
+      (is (= 'foo (dep/resolve-name projects 'foo)))
+      (is (= 'example/bar (dep/resolve-name projects 'bar)))
+      (is (= 'baz/foo (dep/resolve-name projects 'baz/foo)))
+      (is (= 'example/baz (dep/resolve-name projects 'baz)))))
   (testing "unscope-coord"
     (is (= '[example/foo "1.0"] (dep/unscope-coord '[example/foo "1.0"])))
     (is (= '[example/bar "0.5.0" :exclusions [foo]]

--- a/test/lein_monolith/dependency_test.clj
+++ b/test/lein_monolith/dependency_test.clj
@@ -18,6 +18,7 @@
       (is (nil? (dep/resolve-name projects 'qux)))
       (is (nil? (dep/resolve-name projects 'example/qux)))
       (is (= 'foo (dep/resolve-name projects 'foo)))
+      (is (= 'foo (dep/resolve-name projects 'foo/foo)))
       (is (= 'example/bar (dep/resolve-name projects 'bar)))
       (is (= 'baz/foo (dep/resolve-name projects 'baz/foo)))
       (is (= 'example/baz (dep/resolve-name projects 'baz)))))
@@ -35,6 +36,16 @@
     (is (= 'example/bar (dep/dep-source (dep/with-source [:foo "123"] 'example/bar))))))
 
 
+(deftest dependency-mapping
+  (let [projects '{foo/a {:dependencies []}
+                   foo/b {:dependencies [[foo/a "1.0.0"]]}
+                   foo/c {:dependencies [[foo/a "1.0.0"]]}
+                   foo/d {:dependencies [[foo/b "1.0.0"]
+                                         [foo/c "1.0.0"]]}}]
+    (is (= '{foo/a #{}, foo/b #{foo/a}, foo/c #{foo/a}, foo/d #{foo/b foo/c}}
+           (dep/dependency-map projects)))))
+
+
 (deftest upstream-dependency-closure
   (let [deps {:a #{}, :b #{:a}, :c #{:a :b} :x #{:b} :y #{:c}}]
     (is (= #{:a} (dep/upstream-keys deps :a)))
@@ -50,4 +61,15 @@
     (is (= #{:b :c :x :y} (dep/downstream-keys deps :b)))
     (is (= #{:c :y} (dep/downstream-keys deps :c)))
     (is (= #{:x} (dep/downstream-keys deps :x)))
-    (is (= #{:y} (dep/downstream-keys deps :y)))))
+    (is (= #{:y} (dep/downstream-keys deps :y))))
+  (let [deps {:a #{}, :b #{:a}, :c #{:a}, :d #{:b :c}}]
+    (is (= #{:a :b :c :d} (dep/downstream-keys deps :a)))))
+
+
+(deftest topological-sorting
+  (let [deps {:a #{}, :b #{:a}, :c #{:a :b} :x #{:b} :y #{:c}}]
+    (is (= [:a :b :c :x :y] (dep/topological-sort deps)))
+    (is (= [:b :c :x] (dep/topological-sort deps [:x :c :b]))))
+  (let [deps {:a #{:b}, :b #{:c}, :c #{:a}}]
+    (is (thrown-with-msg? Exception #"cycle detected"
+          (dep/topological-sort deps)))))

--- a/test/lein_monolith/dependency_test.clj
+++ b/test/lein_monolith/dependency_test.clj
@@ -38,3 +38,21 @@
          (dep/subtree-from {:a [], :b [:a], :c [:a]} :b)))
   (is (= {:a #{}, :b #{:a :x}}
          (dep/subtree-from {:a [], :b [:a :x], :c [:a]} :b))))
+
+
+(deftest upstream-dependency-closure
+  (let [deps {:a #{}, :b #{:a}, :c #{:a :b} :x #{:b} :y #{:c}}]
+    (is (= #{:a} (dep/upstream-keys deps :a)))
+    (is (= #{:a :b} (dep/upstream-keys deps :b)))
+    (is (= #{:a :b :c} (dep/upstream-keys deps :c)))
+    (is (= #{:a :b :x} (dep/upstream-keys deps :x)))
+    (is (= #{:a :b :c :y} (dep/upstream-keys deps :y)))))
+
+
+(deftest downstream-dependency-closure
+  (let [deps {:a #{}, :b #{:a}, :c #{:a :b} :x #{:b} :y #{:c}}]
+    (is (= #{:a :b :c :x :y} (dep/downstream-keys deps :a)))
+    (is (= #{:b :c :x :y} (dep/downstream-keys deps :b)))
+    (is (= #{:c :y} (dep/downstream-keys deps :c)))
+    (is (= #{:x} (dep/downstream-keys deps :x)))
+    (is (= #{:y} (dep/downstream-keys deps :y)))))


### PR DESCRIPTION
This PR adds a few new features to the plugin:
- Tasks taking project identifier arguments can be specified using only the name in most cases, rather than the full namespaced symbol.
- The `each` and `info` tasks take a set of _target selection_ options which offer fine-grained control over the dependency closure of the projects. These include `in`, `upstream[-of]`, and `downstream[-of]`, as well as the ability to specify multiple `selector` keys to apply more than one filter.
- Improvements to how keyword args are processed by the task plugin to make it easier to specify behavior for options which can occur multiple times.