### PR TITLE
Capture project output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-...
+### Added
+- New `:output` option to `each` task allows saving individual subproject output
+  to separate files under the given directory.
+
+### Fixed
+- Tasks run with `each` now use the subproject's root as the working directory,
+  rather than the monolith root. [#21](https://github.com/amperity/lein-monolith/issues/21)
 
 ## [0.3.2] - 2017-03-21
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ In addition to targeting options, `each` accepts:
   is useful in situations such as CI tests, where you don't want a failure to
   halt iteration.
 - `:report` show a detailed timing report after the tasks finish executing.
+- `:output` path to a directory to save individual build output in.
 
 ### Merged Source Profile
 

--- a/example/project.clj
+++ b/example/project.clj
@@ -2,7 +2,7 @@
   :description "Overarching example project."
 
   :plugins
-  [[lein-monolith "0.3.2"]
+  [[lein-monolith "0.3.3-SNAPSHOT"]
    [lein-cprint "1.2.0"]]
 
   :dependencies

--- a/src/lein_monolith/task/each.clj
+++ b/src/lein_monolith/task/each.clj
@@ -21,6 +21,7 @@
     {:parallel 1
      :endure 0
      :report 0
+     :output 1
      :upstream 0
      :downstream 0
      :start 1}))
@@ -37,6 +38,8 @@
       [:endure])
     (when (:report opts)
       [:report])
+    (when-let [out-dir (:output opts)]
+      [:output out-dir])
     (when-let [in (seq (:in opts))]
       [:in (str/join "," in)])
     (when (:upstream opts)

--- a/src/lein_monolith/task/each.clj
+++ b/src/lein_monolith/task/each.clj
@@ -201,7 +201,8 @@
             [:default :monolith/inherited]
             [:default])))
       (config/debug-profile "apply-task"
-        (lein/resolve-and-apply subproject task)))))
+        (binding [eval/*dir* (:root subproject)]
+          (lein/resolve-and-apply subproject task))))))
 
 
 (defn- run-task!

--- a/src/lein_monolith/task/each.clj
+++ b/src/lein_monolith/task/each.clj
@@ -221,9 +221,19 @@
         ; Capture output to file.
         (let [out-file (io/file out-dir (:group subproject) (str (:name subproject) ".txt"))]
           (io/make-parents out-file)
-          (with-redefs [leiningen.core.eval/sh run-with-output]
-            (binding [*task-output-file* out-file]
-              (apply-subproject-task (:monolith ctx) subproject (:task ctx)))))
+          (spit out-file
+                (format "Applying task to %s: %s\n\n"
+                        target
+                        (str/join " " (:task ctx)))
+                :append true)
+          (try
+            (with-redefs [leiningen.core.eval/sh run-with-output]
+              (binding [*task-output-file* out-file]
+                (apply-subproject-task (:monolith ctx) subproject (:task ctx))))
+            (finally
+              (spit out-file
+                    (format "\nElapsed: %s\n" (u/human-duration (:elapsed @results)))
+                    :append true))))
         ; Run without output capturing.
         (apply-subproject-task (:monolith ctx) subproject (:task ctx)))
       (assoc @results :success true)


### PR DESCRIPTION
This change adds a new argument `:output` to the `each` task iterator which appends all task output to project-specific text files under the given directory. It's a little hairy in that lein-monolith has to rebind `leiningen.core.eval/sh` to use a version that handles the subprocess IO differently, but seems to work so far in testing. One gotcha I ran into is that redefs are _not_ thread-safe, but `sh` isn't dynamic, so we have to use both `with-redefs` and `binding` to get the right thread visibility here.

Note that this will not work with subprojects which specify `:eval-in :leiningen` or `:eval-in :nrepl`.