### PR TITLE
Leaky inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-...
+### Added
+- Metaprojects can specify an `:inherit-leaky` vector to generate a leaky
+  profile for inclusion in subprojects' built artifacts.
 
 ## [1.0.0]
 

--- a/doc/config.md
+++ b/doc/config.md
@@ -24,3 +24,10 @@ A value of `true` will merge in a profile with the attributes set in the
 metaproject. Alternately, you can provide a vector of additional keys to merge
 from the metaproject. Attaching `^:replace` metadata will cause the vector to
 override the attributes set in the metaproject.
+
+Some metaproject settings are only useful if they are still present in the
+generated build artifacts for the subprojects. The primary examples of these are
+`:repositories` and `:managed-dependencies`. For these, you can specify a second
+key in the metaproject called `:inherit-leaky`, which follows the format of
+`:inherit` above. Properties in this profile will be included in the built JAR
+and pom files for the subproject.

--- a/example/project.clj
+++ b/example/project.clj
@@ -2,7 +2,7 @@
   :description "Overarching example project."
 
   :plugins
-  [[lein-monolith "0.3.3-SNAPSHOT"]
+  [[lein-monolith "1.0.1-SNAPSHOT"]
    [lein-cprint "1.2.0"]]
 
   :dependencies
@@ -14,8 +14,11 @@
 
   :monolith
   {:inherit
+   [:test-selectors
+    :env]
+
+   :inherit-leaky
    [:repositories
-    :test-selectors
     :managed-dependencies]
 
    :project-selectors
@@ -25,4 +28,7 @@
    :project-dirs
    ["apps/app-a"
     "libs/*"
-    "not-found"]})
+    "not-found"]}
+
+  :env
+  {:foo "bar"})

--- a/src/lein_monolith/task/each.clj
+++ b/src/lein_monolith/task/each.clj
@@ -189,9 +189,12 @@
   [monolith subproject task]
   (binding [lein/*exit-process?* false]
     (as-> subproject subproject
-      (if-let [inherited (:monolith/inherit subproject)]
-        (assoc-in subproject [:profiles :monolith/inherited]
-                  (plugin/inherited-profile monolith inherited))
+      (if-let [inherited (plugin/inherited-profile
+                           monolith
+                           (:monolith/inherit subproject))]
+        (-> subproject
+            (merge (plugin/inherited-injections monolith inherited))
+            (assoc-in [:profiles :monolith/inherited] inherited))
         subproject)
       (config/debug-profile "init-subproject"
         (project/init-project

--- a/src/lein_monolith/task/info.clj
+++ b/src/lein_monolith/task/info.clj
@@ -17,15 +17,19 @@
   (let [monolith (config/find-monolith! project)]
     (when-not (:bare opts)
       (println "Monolith root:" (:root monolith))
-      (println)
+      (newline)
       (when-let [inherited (get-in monolith [:monolith :inherit])]
         (println "Inherited properties:")
         (puget/cprint inherited)
-        (println))
+        (newline))
+      (when-let [inherited (get-in monolith [:monolith :inherit-leaky])]
+        (println "Inherited (leaky) properties:")
+        (puget/cprint inherited)
+        (newline))
       (when-let [dirs (get-in monolith [:monolith :project-dirs])]
         (println "Subproject directories:")
         (puget/cprint dirs)
-        (println)))
+        (newline)))
     (let [subprojects (config/read-subprojects! monolith)
           dependencies (dep/dependency-map subprojects)
           targets (target/select monolith subprojects opts)


### PR DESCRIPTION
This change enables the inheritance of metaproject attributes which must be included in the subproject's built artifacts in order to be useful. Specifically, this allows for sharing `:repositories` and `:managed-dependencies` from the metaproject, a long-awaited feature!