### PR TITLE
Fix crash in lein-monolith graph when root and cluster name are equal

### DIFF
--- a/src/lein_monolith/task/graph.clj
+++ b/src/lein_monolith/task/graph.clj
@@ -9,11 +9,13 @@
 
 (def image-name "project-hierarchy.png")
 
+
 (defn cluster->descriptor
   [monolith-root subdirectory]
-  (when-not (= monolith-root subdirectory)
+  (when (not= monolith-root subdirectory)
     {:label (subs (str subdirectory)
                   (inc (count monolith-root)))}))
+
 
 (defn graph
   "Generate a graph of subprojects and their interdependencies."


### PR DESCRIPTION
Running `lein monolith graph` on our project currently produces `java.lang.StringIndexOutOfBoundsException: String index out of range: -1`. This only happens when the name of a cluster (the `%` in the anonymous function) is equal to the root of the project.

The end result after this PR is that clusters at the root of the project have no label, while those that aren't get a label.