### PR TITLE
Allow colours to be disabled

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -31,3 +31,19 @@ generated build artifacts for the subprojects. The primary examples of these are
 key in the metaproject called `:inherit-leaky`, which follows the format of
 `:inherit` above. Properties in this profile will be included in the built JAR
 and pom files for the subproject.
+
+## Controlling color output
+
+monolith uses colored text to highlight important information. This
+can be disabled by adding `:print-color false` in the `:monolith`
+section of your `project.clj`.
+
+You can conditionally enable/disable color output by using a profile
+like this:
+
+```clojure
+:profiles {:ci {:monolith {:print-color false}}}
+```
+
+And then using `lein with-profile +ci monolith ...` when you want to
+disable color printing.

--- a/example/project.clj
+++ b/example/project.clj
@@ -30,5 +30,7 @@
     "libs/*"
     "not-found"]}
 
+  :profiles {:ci {:monolith {:print-color false}}}
+
   :env
   {:foo "bar"})

--- a/src/lein_monolith/ansi.clj
+++ b/src/lein_monolith/ansi.clj
@@ -1,0 +1,13 @@
+(ns lein-monolith.ansi
+  (:require
+    [puget.color.ansi :as ansi]
+    [puget.printer :as puget]))
+
+
+(defn maybe-sgr
+  "If colour printing hasn't been disabled, wraps the given string
+  with SGR escapes to apply the given codes, then reset the graphics."
+  [string & codes]
+  (if (:print-color puget.printer/*options*)
+    (apply ansi/sgr string codes)
+    string))

--- a/src/lein_monolith/dependency.clj
+++ b/src/lein_monolith/dependency.clj
@@ -4,7 +4,7 @@
     [clojure.set :as set]
     [clojure.string :as str]
     [leiningen.core.main :as lein]
-    [puget.color.ansi :as ansi]
+    [lein-monolith.ansi :as ansi]
     [puget.printer :as puget]))
 
 
@@ -193,7 +193,7 @@
                  (count (distinct (map dep-source specs)))
                  " projects - using " (pr-str default-choice) " from "
                  (dep-source default-choice))
-            (ansi/sgr :red)
+            (ansi/maybe-sgr :red)
             (lein/warn))
         (doseq [[spec projects] projects-for-specs]
           (lein/warn (format "%-50s from %s"

--- a/src/lein_monolith/task/info.clj
+++ b/src/lein_monolith/task/info.clj
@@ -3,12 +3,12 @@
     [clojure.string :as str]
     [leiningen.core.main :as lein]
     (lein-monolith
+      [ansi :as ansi]
       [config :as config]
       [dependency :as dep]
       [target :as target])
     [lein-monolith.task.util :as u]
-    [puget.printer :as puget]
-    [puget.color.ansi :as ansi]))
+    [puget.printer :as puget]))
 
 
 (defn info
@@ -43,7 +43,7 @@
           (println subproject-name relative-path)
           (printf "  %-90s   %s\n"
                   (puget/cprint-str [subproject-name version])
-                  (ansi/sgr relative-path :cyan)))))))
+                  (ansi/maybe-sgr relative-path :cyan)))))))
 
 
 (defn lint
@@ -68,7 +68,7 @@
                             project-names)]
     (doseq [dep-name resolved-names]
       (when-not (:bare opts)
-        (lein/info "\nSubprojects which depend on" (ansi/sgr dep-name :bold :yellow)))
+        (lein/info "\nSubprojects which depend on" (ansi/maybe-sgr dep-name :bold :yellow)))
       (doseq [subproject-name (dep/topological-sort dep-map)
               :let [{:keys [version dependencies]} (get subprojects subproject-name)]]
         (when-let [spec (first (filter (comp #{dep-name} dep/condense-name first) dependencies))]
@@ -90,7 +90,7 @@
       (when-not (get dep-map project-name)
         (lein/abort project-name "is not a valid subproject!"))
       (when-not (:bare opts)
-        (lein/info "\nSubprojects which" (ansi/sgr project-name :bold :yellow)
+        (lein/info "\nSubprojects which" (ansi/maybe-sgr project-name :bold :yellow)
                    (if (:transitive opts)
                      "transitively depends on"
                      "depends on")))

--- a/src/lein_monolith/task/util.clj
+++ b/src/lein_monolith/task/util.clj
@@ -1,7 +1,8 @@
 (ns lein-monolith.task.util
   "Utility functions for task code."
   (:require
-    [lein-monolith.config :as config]))
+    [lein-monolith.config :as config]
+    [puget.color.ansi :as ansi]))
 
 
 (defn parse-kw-args

--- a/src/leiningen/monolith.clj
+++ b/src/leiningen/monolith.clj
@@ -186,8 +186,8 @@
   {:subtasks [#'info #'lint #'deps-on #'deps-of #'graph
               #'with-all #'each #'link #'unlink]}
   [project command & args]
-  (puget/with-color
-   (case command
+  (puget/with-options {:print-color (get-in project [:monolith :print-color] true)}
+    (case command
      "info"       (info project args)
      "lint"       (lint project args)
      "deps-on"    (deps-on project args)

--- a/src/leiningen/monolith.clj
+++ b/src/leiningen/monolith.clj
@@ -18,8 +18,7 @@
       [graph :as graph]
       [info :as info]
       [util :as u])
-    [puget.printer :as puget]
-    [puget.color.ansi :as ansi]))
+    [puget.printer :as puget]))
 
 
 (defn- opts-only
@@ -187,15 +186,16 @@
   {:subtasks [#'info #'lint #'deps-on #'deps-of #'graph
               #'with-all #'each #'link #'unlink]}
   [project command & args]
-  (case command
-    "info"       (info project args)
-    "lint"       (lint project args)
-    "deps-on"    (deps-on project args)
-    "deps-of"    (deps-of project args)
-    "graph"      (graph project)
-    "with-all"   (with-all project args)
-    "each"       (each project args)
-    "link"       (link project args)
-    "unlink"     (unlink project)
-    (lein/abort (pr-str command) "is not a valid monolith command! Try: lein help monolith"))
+  (puget/with-color
+   (case command
+     "info"       (info project args)
+     "lint"       (lint project args)
+     "deps-on"    (deps-on project args)
+     "deps-of"    (deps-of project args)
+     "graph"      (graph project)
+     "with-all"   (with-all project args)
+     "each"       (each project args)
+     "link"       (link project args)
+     "unlink"     (unlink project)
+     (lein/abort (pr-str command) "is not a valid monolith command! Try: lein help monolith")))
   (flush))


### PR DESCRIPTION
`lein-monolith` currently puts ANSI escape codes directly in its output, which is very nice for terminals but not so much for logs in our CI system. This PR makes it possible to opt-out of the coloured output.

All it takes is a profile like this:

```clojure
:profiles
  {:ci {:monolith {:print-color false}}}
```

and then configuring our CI to be run as `lein with-profile +ci monolith ...`.

I'm not 100% sure if this is the right interface though. A few concerns I have:

  * Puget has a bunch of other print options - maybe they should all be supported? A nested `:puget` section inside `:monolith` could work, or just pass the entire `:monolith` map as the Puget options and avoid the nesting.
  * I don't love the idea of adding more and more keys into the `:monolith` map. A lot of Leiningen plugins have a dozen configuration options, and they can take a lot of effort to set up. Initially I hoped Leiningen's generic `:injections` functionality could avoid the need for any special configuration. But using `set!` to make `:print-color` `false` is actually the same as the existing defaults, so monolith can't distinguish between the two.