### PR TITLE
Allow graph subtask to take targeting options

### DIFF
--- a/src/lein_monolith/task/graph.clj
+++ b/src/lein_monolith/task/graph.clj
@@ -27,9 +27,11 @@
         targets (target/select monolith subprojects opts)
         dependencies (dep/dependency-map subprojects)
         graph-file (io/file (:target-path monolith) image-name)]
+    (when (empty? targets)
+      (lein/abort "No targets selected to graph!"))
     (.mkdir (.getParentFile graph-file))
     (visualize!
-      (or (seq targets) (keys dependencies))
+      targets
       dependencies
       :vertical? false
       :node->descriptor #(array-map :label (name %))

--- a/src/lein_monolith/task/graph.clj
+++ b/src/lein_monolith/task/graph.clj
@@ -4,6 +4,7 @@
     [clojure.string :as str]
     [leiningen.core.main :as lein]
     [lein-monolith.dependency :as dep]
+    [lein-monolith.target :as target]
     [lein-monolith.task.util :as u]))
 
 
@@ -19,15 +20,16 @@
 
 (defn graph
   "Generate a graph of subprojects and their interdependencies."
-  [project]
+  [project opts]
   (require 'rhizome.viz)
   (let [visualize! (ns-resolve 'rhizome.viz 'save-graph)
         [monolith subprojects] (u/load-monolith! project)
+        targets (target/select monolith subprojects opts)
         dependencies (dep/dependency-map subprojects)
         graph-file (io/file (:target-path monolith) image-name)]
     (.mkdir (.getParentFile graph-file))
     (visualize!
-      (keys dependencies)
+      (or (seq targets) (keys dependencies))
       dependencies
       :vertical? false
       :node->descriptor #(array-map :label (name %))

--- a/src/leiningen/monolith.clj
+++ b/src/leiningen/monolith.clj
@@ -84,8 +84,8 @@
 
 (defn graph
   "Generate a graph of subprojects and their interdependencies."
-  [project]
-  (graph/graph project))
+  [project args]
+  (graph/graph project (opts-only target/selection-opts args)))
 
 
 (defn ^:higher-order with-all
@@ -243,7 +243,7 @@
     "lint"               (lint project args)
     "deps-on"            (deps-on project args)
     "deps-of"            (deps-of project args)
-    "graph"              (graph project)
+    "graph"              (graph project args)
     "with-all"           (with-all project args)
     "each"               (each project args)
     "link"               (link project args)


### PR DESCRIPTION
This is useful for scoping the resulting graph down to a smaller set of projects.