### PR TITLE
Don't exit `each` in the no-op case to allow composition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- The `each` subtask couldn't be composed with subsequent tasks if it had no
+  work to do. [#44](https://github.com/amperity/lein-monolith/pull/44)
+
 ## [1.2.0] - 2019-01-08
 
 ### Changed

--- a/src/lein_monolith/task/each.clj
+++ b/src/lein_monolith/task/each.clj
@@ -334,36 +334,36 @@
                   (u/globalize-opts project opts))
         n (inc (or (first (last targets)) -1))
         start-time (System/nanoTime)]
-    (when (empty? targets)
+    (if (empty? targets)
       (lein/info "Target selection matched zero subprojects; nothing to do")
-      (lein/exit 0))
-    (lein/info "Applying"
-               (ansi/sgr (str/join " " task) :bold :cyan)
-               "to" (ansi/sgr (count targets) :cyan)
-               "subprojects...")
-    (let [ctx {:monolith monolith
-               :subprojects subprojects
-               :fingerprints fprints
-               :completions (atom (ffirst targets))
-               :num-targets n
-               :task task
-               :opts opts}
-          results (if-let [threads (:parallel opts)]
-                    (run-parallel! ctx (Integer/parseInt threads) targets)
-                    (run-linear! ctx targets))
-          elapsed (/ (- (System/nanoTime) start-time) 1000000.0)]
-      (when (:report opts)
-        (print-report results elapsed))
-      (if-let [failures (seq (map :name (remove :success results)))]
-        (lein/abort (format "\n%s: Applied %s to %s projects in %s with %d failures: %s"
-                            (ansi/sgr "FAILURE" :bold :red)
-                            (ansi/sgr (str/join " " task) :bold :cyan)
-                            (ansi/sgr (count targets) :cyan)
-                            (u/human-duration elapsed)
-                            (count failures)
-                            (str/join " " failures)))
-        (lein/info (format "\n%s: Applied %s to %s projects in %s"
-                           (ansi/sgr "SUCCESS" :bold :green)
-                           (ansi/sgr (str/join " " task) :bold :cyan)
-                           (ansi/sgr (count targets) :cyan)
-                           (u/human-duration elapsed)))))))
+      (do
+        (lein/info "Applying"
+                   (ansi/sgr (str/join " " task) :bold :cyan)
+                   "to" (ansi/sgr (count targets) :cyan)
+                   "subprojects...")
+        (let [ctx {:monolith monolith
+                   :subprojects subprojects
+                   :fingerprints fprints
+                   :completions (atom (ffirst targets))
+                   :num-targets n
+                   :task task
+                   :opts opts}
+              results (if-let [threads (:parallel opts)]
+                        (run-parallel! ctx (Integer/parseInt threads) targets)
+                        (run-linear! ctx targets))
+              elapsed (/ (- (System/nanoTime) start-time) 1000000.0)]
+          (when (:report opts)
+            (print-report results elapsed))
+          (if-let [failures (seq (map :name (remove :success results)))]
+            (lein/abort (format "\n%s: Applied %s to %s projects in %s with %d failures: %s"
+                                (ansi/sgr "FAILURE" :bold :red)
+                                (ansi/sgr (str/join " " task) :bold :cyan)
+                                (ansi/sgr (count targets) :cyan)
+                                (u/human-duration elapsed)
+                                (count failures)
+                                (str/join " " failures)))
+            (lein/info (format "\n%s: Applied %s to %s projects in %s"
+                               (ansi/sgr "SUCCESS" :bold :green)
+                               (ansi/sgr (str/join " " task) :bold :cyan)
+                               (ansi/sgr (count targets) :cyan)
+                               (u/human-duration elapsed)))))))))


### PR DESCRIPTION
`lein monolith each` currently exits with 0 if the selectors match zero projects. This terminates the leiningen process even if you try to compose `each` in a high-level task:

```
$ lein do monolith each :refresh build install, version
Target selection matched zero subprojects; nothing to do
```

Instead it now "soft-exits" to allow subsequent tasks.