### PR TITLE
Un-puget

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 executors:
   clojure:
     docker:
-      - image: circleci/clojure:openjdk-8-lein-2.9.1
+      - image: circleci/clojure:openjdk-11-lein-2.9.1
     working_directory: ~/repo
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,11 @@ jobs:
       - checkout
       - run:
           name: Install cljfmt CLI
-          command: "wget https://github.com/greglook/cljfmt/releases/download/0.8.1/cljfmt_0.8.1_linux.tar.gz && tar -xzf cljfmt_0.8.1_linux.tar.gz"
+          environment:
+            CLJFMT_VERSION: 0.8.2
+          command: |
+            wget https://github.com/greglook/cljfmt/releases/download/${CLJFMT_VERSION}/cljfmt_${CLJFMT_VERSION}_linux.tar.gz
+            tar -xzf cljfmt_${CLJFMT_VERSION}_linux.tar.gz
       - run:
           name: Check source formatting
           command: "./cljfmt check --stats style-stats.tsv"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 executors:
   clojure:
     docker:
-      - image: circleci/clojure:lein-2.9.1
+      - image: circleci/clojure:openjdk-8-lein-2.9.1
     working_directory: ~/repo
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-...
+### Changed
+- Remove dependency on `puget` for colorized output and canonical printing. This
+  avoids pulling in `fipp` which is problematic on Java 9+.
 
 ## [1.2.2] - 2019-09-11
 

--- a/example/project.clj
+++ b/example/project.clj
@@ -2,7 +2,7 @@
   :description "Overarching example project."
 
   :plugins
-  [[lein-monolith "1.0.2-SNAPSHOT"]
+  [[lein-monolith "1.2.3-SNAPSHOT"]
    [lein-cprint "1.2.0"]]
 
   :dependencies

--- a/example/project.clj
+++ b/example/project.clj
@@ -3,7 +3,7 @@
 
   :plugins
   [[lein-monolith "1.2.3-SNAPSHOT"]
-   [lein-cprint "1.2.0"]]
+   [lein-pprint "1.2.0"]]
 
   :dependencies
   [[org.clojure/clojure "1.8.0"]]

--- a/project.clj
+++ b/project.clj
@@ -9,14 +9,13 @@
 
   :dependencies
   [[manifold "0.1.8"]
-   [mvxcvi/puget "1.1.2"]
    [rhizome "0.2.9"]]
 
   :hiera
   {:vertical false
    :show-external true
    :cluster-depth 1
-   :ignore-ns #{clojure puget manifold}}
+   :ignore-ns #{clojure manifold}}
 
   :profiles
   {:dev {:plugins [[lein-cloverage "1.0.9"]]

--- a/src/lein_monolith/color.clj
+++ b/src/lein_monolith/color.clj
@@ -1,0 +1,61 @@
+(ns lein-monolith.color
+  "Coloring functions which apply ANSI color codes to color terminal output."
+  (:require
+    [clojure.string :as str]))
+
+
+(def ^:private sgr-code
+  "Map of symbols to numeric SGR (select graphic rendition) codes."
+  {:none        0
+   :bold        1
+   :underline   3
+   :blink       5
+   :reverse     7
+   :hidden      8
+   :strike      9
+   :black      30
+   :red        31
+   :green      32
+   :yellow     33
+   :blue       34
+   :magenta    35
+   :cyan       36
+   :white      37
+   :fg-256     38
+   :fg-reset   39
+   :bg-black   40
+   :bg-red     41
+   :bg-green   42
+   :bg-yellow  43
+   :bg-blue    44
+   :bg-magenta 45
+   :bg-cyan    46
+   :bg-white   47
+   :bg-256     48
+   :bg-reset   49})
+
+
+(def ^:dynamic *enabled*
+  "Whether to render text with color."
+  true)
+
+
+(defn- sgr
+  "Returns an ANSI escope string which will apply the given collection of SGR
+  codes."
+  [codes]
+  (let [codes (map sgr-code codes codes)
+        codes (str/join \; codes)]
+    (str \u001b \[ codes \m)))
+
+
+(defn colorize
+  "Wraps the given string with SGR escapes to apply the given codes, then reset
+  the graphics. If `*enabled*` is not truthy, returns the string unaltered."
+  [codes string]
+  (if *enabled*
+    (let [codes (if (keyword? codes)
+                  [codes]
+                  (vec codes))]
+      (str (sgr codes) string (sgr [:none])))
+    string))

--- a/src/lein_monolith/color.clj
+++ b/src/lein_monolith/color.clj
@@ -35,9 +35,13 @@
    :bg-reset   49})
 
 
-(def ^:dynamic *enabled*
-  "Whether to render text with color."
-  true)
+(def enabled?
+  "Delay which yields true if text should be rendered with color."
+  (delay
+    (let [env (System/getenv "LEIN_MONOLITH_COLOR")
+          disabled?  (and env (contains? #{"no" "false" "off"}
+                                         (str/lower-case env)))]
+      (not disabled?))))
 
 
 (defn- sgr
@@ -53,7 +57,7 @@
   "Wraps the given string with SGR escapes to apply the given codes, then reset
   the graphics. If `*enabled*` is not truthy, returns the string unaltered."
   [codes string]
-  (if *enabled*
+  (if @enabled?
     (let [codes (if (keyword? codes)
                   [codes]
                   (vec codes))]

--- a/src/lein_monolith/dependency.clj
+++ b/src/lein_monolith/dependency.clj
@@ -3,8 +3,8 @@
   (:require
     [clojure.set :as set]
     [clojure.string :as str]
+    [lein-monolith.color :refer [colorize]]
     [leiningen.core.main :as lein]
-    [puget.color.ansi :as ansi]
     [puget.printer :as puget]))
 
 
@@ -196,13 +196,13 @@
       default-choice
       ; Multiple versions or specs declared! Warn and use the default.
       (do
-        (-> (str "WARN: Multiple dependency specs found for "
-                 (condense-name dep-name) " in "
-                 (count (distinct (map dep-source specs)))
-                 " projects - using " (pr-str default-choice) " from "
-                 (dep-source default-choice))
-            (ansi/sgr :red)
-            (lein/warn))
+        (->> (str "WARN: Multiple dependency specs found for "
+                  (condense-name dep-name) " in "
+                  (count (distinct (map dep-source specs)))
+                  " projects - using " (pr-str default-choice) " from "
+                  (dep-source default-choice))
+             (colorize :red)
+             (lein/warn))
         (doseq [[spec projects] projects-for-specs]
           (lein/warn (format "%-50s from %s"
                              (puget/cprint-str spec)

--- a/src/lein_monolith/dependency.clj
+++ b/src/lein_monolith/dependency.clj
@@ -4,8 +4,7 @@
     [clojure.set :as set]
     [clojure.string :as str]
     [lein-monolith.color :refer [colorize]]
-    [leiningen.core.main :as lein]
-    [puget.printer :as puget]))
+    [leiningen.core.main :as lein]))
 
 
 ;; ## Coordinate Functions
@@ -205,7 +204,7 @@
              (lein/warn))
         (doseq [[spec projects] projects-for-specs]
           (lein/warn (format "%-50s from %s"
-                             (puget/cprint-str spec)
+                             (pr-str spec)
                              (str/join " " (sort projects)))))
         (lein/warn "")
         default-choice))))

--- a/src/lein_monolith/plugin.clj
+++ b/src/lein_monolith/plugin.clj
@@ -7,8 +7,7 @@
     [lein-monolith.config :as config]
     [lein-monolith.dependency :as dep]
     [leiningen.core.main :as lein]
-    [leiningen.core.project :as project]
-    [puget.printer :as puget]))
+    [leiningen.core.project :as project]))
 
 
 ;; ## Profile Generation

--- a/src/lein_monolith/plugin.clj
+++ b/src/lein_monolith/plugin.clj
@@ -8,7 +8,6 @@
     [lein-monolith.dependency :as dep]
     [leiningen.core.main :as lein]
     [leiningen.core.project :as project]
-    [puget.color.ansi :as ansi]
     [puget.printer :as puget]))
 
 

--- a/src/lein_monolith/task/info.clj
+++ b/src/lein_monolith/task/info.clj
@@ -1,12 +1,12 @@
 (ns lein-monolith.task.info
   (:require
     [clojure.string :as str]
+    [lein-monolith.color :refer [colorize]]
     [lein-monolith.config :as config]
     [lein-monolith.dependency :as dep]
     [lein-monolith.target :as target]
     [lein-monolith.task.util :as u]
     [leiningen.core.main :as lein]
-    [puget.color.ansi :as ansi]
     [puget.printer :as puget]))
 
 
@@ -33,6 +33,7 @@
           dependencies (dep/dependency-map subprojects)
           targets (target/select monolith subprojects opts)
           prefix-len (inc (count (:root monolith)))]
+      ; IDEA: some kind of stats about dependency graph shape
       (when-not (:bare opts)
         (printf "Internal projects (%d):\n" (count targets)))
       (doseq [subproject-name (dep/topological-sort dependencies targets)
@@ -42,7 +43,7 @@
           (println subproject-name relative-path)
           (printf "  %-90s   %s\n"
                   (puget/cprint-str [subproject-name version])
-                  (ansi/sgr relative-path :cyan)))))))
+                  (colorize :cyan relative-path)))))))
 
 
 (defn lint
@@ -67,7 +68,7 @@
                             project-names)]
     (doseq [dep-name resolved-names]
       (when-not (:bare opts)
-        (lein/info "\nSubprojects which depend on" (ansi/sgr dep-name :bold :yellow)))
+        (lein/info "\nSubprojects which depend on" (colorize [:bold :yellow] dep-name)))
       (doseq [subproject-name (dep/topological-sort dep-map)
               :let [{:keys [version dependencies]} (get subprojects subproject-name)]]
         (when-let [spec (first (filter (comp #{dep-name} dep/condense-name first) dependencies))]
@@ -89,7 +90,7 @@
       (when-not (get dep-map project-name)
         (lein/abort project-name "is not a valid subproject!"))
       (when-not (:bare opts)
-        (lein/info "\nSubprojects which" (ansi/sgr project-name :bold :yellow)
+        (lein/info "\nSubprojects which" (colorize [:bold :yellow] project-name)
                    (if (:transitive opts)
                      "transitively depends on"
                      "depends on")))

--- a/src/lein_monolith/task/info.clj
+++ b/src/lein_monolith/task/info.clj
@@ -6,8 +6,7 @@
     [lein-monolith.dependency :as dep]
     [lein-monolith.target :as target]
     [lein-monolith.task.util :as u]
-    [leiningen.core.main :as lein]
-    [puget.printer :as puget]))
+    [leiningen.core.main :as lein]))
 
 
 (defn info
@@ -19,15 +18,18 @@
       (newline)
       (when-let [inherited (get-in monolith [:monolith :inherit])]
         (println "Inherited properties:")
-        (puget/cprint inherited)
+        (doseq [kw inherited]
+          (println (colorize [:bold :yellow] kw)))
         (newline))
       (when-let [inherited (get-in monolith [:monolith :inherit-leaky])]
         (println "Inherited (leaky) properties:")
-        (puget/cprint inherited)
+        (doseq [kw inherited]
+          (println (colorize [:bold :yellow] kw)))
         (newline))
       (when-let [dirs (get-in monolith [:monolith :project-dirs])]
         (println "Subproject directories:")
-        (puget/cprint dirs)
+        (doseq [dir dirs]
+          (println (colorize :magenta dir)))
         (newline)))
     (let [subprojects (config/read-subprojects! monolith)
           dependencies (dep/dependency-map subprojects)
@@ -42,7 +44,11 @@
         (if (:bare opts)
           (println subproject-name relative-path)
           (printf "  %-90s   %s\n"
-                  (puget/cprint-str [subproject-name version])
+                  (str (colorize :red \[)
+                       subproject-name
+                       \space
+                       (colorize :magenta (pr-str version))
+                       (colorize :red \]))
                   (colorize :cyan relative-path)))))))
 
 
@@ -74,8 +80,8 @@
         (when-let [spec (first (filter (comp #{dep-name} dep/condense-name first) dependencies))]
           (if (:bare opts)
             (println subproject-name (first spec) (second spec))
-            (println "  " (puget/cprint-str subproject-name)
-                     "->" (puget/cprint-str spec))))))))
+            (println "  " (colorize :bold subproject-name)
+                     "->" (colorize :bold spec))))))))
 
 
 (defn deps-of
@@ -101,5 +107,5 @@
                     (dep-map project-name))]
         (if (:bare opts)
           (println project-name dep)
-          (println "  " (puget/cprint-str project-name)
+          (println "  " (colorize :bold project-name)
                    "->" dep))))))

--- a/src/leiningen/monolith.clj
+++ b/src/leiningen/monolith.clj
@@ -1,9 +1,7 @@
 (ns leiningen.monolith
   "Leiningen task implementations for working with monorepos."
   (:require
-    [clojure.set :as set]
     [clojure.string :as str]
-    [lein-monolith.config :as config]
     [lein-monolith.dependency :as dep]
     [lein-monolith.plugin :as plugin]
     [lein-monolith.target :as target]
@@ -13,10 +11,7 @@
     [lein-monolith.task.graph :as graph]
     [lein-monolith.task.info :as info]
     [lein-monolith.task.util :as u]
-    [leiningen.core.main :as lein]
-    [leiningen.core.project :as project]
-    [puget.color.ansi :as ansi]
-    [puget.printer :as puget]))
+    [leiningen.core.main :as lein]))
 
 
 (defn- opts-only

--- a/test/example-tests.sh
+++ b/test/example-tests.sh
@@ -29,12 +29,12 @@ test_monolith info
 test_monolith lint
 test_monolith deps-of example/app-a
 test_monolith deps-on example/lib-a
-test_monolith with-all cprint :dependencies :source-paths
-test_monolith each cprint :version
-test_monolith each :in lib-a cprint :root
-test_monolith each :upstream-of lib-b cprint :version
-test_monolith each :downstream-of lib-a cprint :name
-test_monolith each :parallel 3 :report :endure cprint :group
+test_monolith with-all pprint :dependencies :source-paths
+test_monolith each pprint :version
+test_monolith each :in lib-a pprint :root
+test_monolith each :upstream-of lib-b pprint :version
+test_monolith each :downstream-of lib-a pprint :name
+test_monolith each :parallel 3 :report :endure pprint :group
 test_monolith each :refresh foo install
 test_monolith each :refresh foo install
 test_monolith each :parallel 3 :refresh bar install


### PR DESCRIPTION
## Description

I recently ran into https://github.com/brandonbloom/fipp/issues/60 when CircleCI updated their implicit Java version to 11 on their Clojure container images. Currently `lein-monolith` pulls in `puget` to do its ANSI coloring as well as some canonical printing for project fingerprints. There's not a huge dependency on the actual pretty-printing functionality, so we can simplify some headaches by dropping puget.

## Changes

- Pull in basic ANSI color coding functionality in `lein-monolith.color`.
- Replace all references to `puget.color.ansi` with the new color codes.
- Replace puget pretty printing with either a simpler colored output or a more basic `pprint` or `pr-str` call.
- Rewrite fingerprint canonicalization functions to operate at a more basic key/value level instead of leveraging puget for rendering.

## Testing

Local tests, example test project.