### PR TITLE
Include more attributes in fingerprints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-...
+### Added
+- Subprojects may include a `:monolith/fingerprint-seed` value as a way to force
+  fingerprint invalidations when desired.
 
 ## [1.3.0] - 2019-10-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Subproject fingerprints now include the project's artifact version in the
+  calculation.
+
 ### Added
 - Subprojects may include a `:monolith/fingerprint-seed` value as a way to force
   fingerprint invalidations when desired.

--- a/src/lein_monolith/task/fingerprint.clj
+++ b/src/lein_monolith/task/fingerprint.clj
@@ -165,7 +165,8 @@
   (let [project-name (dep/project-name project)]
     (or (@cache project-name)
         (let [prints
-              {::seed (str (:monolith/fingerprint-seed project 0))
+              {::version (str (:version project))
+               ::seed (str (:monolith/fingerprint-seed project 0))
                ::sources (hash-sources project)
                ::deps (hash-dependencies project)
                ::upstream (hash-upstream-projects
@@ -279,13 +280,15 @@
             (fn [ftype]
               (when (not= (ftype past) (ftype current))
                 ftype))
-            [::sources ::deps ::upstream])
+            [::version ::seed ::sources ::deps ::upstream])
           ::unknown))))
 
 
 (def ^:private reason-details
   {::up-to-date ["is up-to-date" "are up-to-date" :green]
    ::new-project ["is a new project" "are new projects" :red]
+   ::version ["has a different version" "have different versions" :red]
+   ::seed ["has a different seed" "have different seeds" :yellow]
    ::sources ["has updated sources" "have updated sources" :red]
    ::deps ["has updated external dependencies" "have updated external dependencies" :yellow]
    ::upstream ["is downstream of an affected project" "are downstream of affected projects" :yellow]

--- a/src/lein_monolith/task/fingerprint.clj
+++ b/src/lein_monolith/task/fingerprint.clj
@@ -165,7 +165,8 @@
   (let [project-name (dep/project-name project)]
     (or (@cache project-name)
         (let [prints
-              {::sources (hash-sources project)
+              {::seed (str (:monolith/fingerprint-seed project 0))
+               ::sources (hash-sources project)
                ::deps (hash-dependencies project)
                ::upstream (hash-upstream-projects
                             project dep-map subprojects cache)}


### PR DESCRIPTION
Some things can affect the artifact produced by a project without changing the project's fingerprint. The obvious one we weren't accounting for is the project version, but there are other things which might do this too that we can't forsee. To allow the user a way to cache-bust explicitly, the fingerprint also includes the `:monolith/fingerprint-seed` from the project definition if set. This way a simple increment can force a rebuild without having to affect other aspects of the build.