### PR TITLE
Include project profile dependencies in overall dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ...
 
+## [1.3.2] - 2019-10-21
+
+### Fixed
+- Subproject dependency calculation now includes dependencies declared in the
+  project's profiles.
+  [#51](https://github.com/amperity/lein-monolith/pull/51)
+
 ## [1.3.1] - 2019-10-14
 
 ### Fixed
@@ -208,7 +215,8 @@ instead of loading them all before running any commands.
 
 Initial project release
 
-[Unreleased]: https://github.com/amperity/lein-monolith/compare/1.3.1...HEAD
+[Unreleased]: https://github.com/amperity/lein-monolith/compare/1.3.2...HEAD
+[1.3.2]: https://github.com/amperity/lein-monolith/compare/1.3.1...1.3.2
 [1.3.1]: https://github.com/amperity/lein-monolith/compare/1.3.0...1.3.1
 [1.3.0]: https://github.com/amperity/lein-monolith/compare/1.2.2...1.3.0
 [1.2.2]: https://github.com/amperity/lein-monolith/compare/1.2.1...1.2.2

--- a/example/project.clj
+++ b/example/project.clj
@@ -2,7 +2,7 @@
   :description "Overarching example project."
 
   :plugins
-  [[lein-monolith "1.3.2-SNAPSHOT"]
+  [[lein-monolith "1.3.2"]
    [lein-pprint "1.2.0"]]
 
   :dependencies

--- a/example/project.clj
+++ b/example/project.clj
@@ -2,7 +2,7 @@
   :description "Overarching example project."
 
   :plugins
-  [[lein-monolith "1.3.2"]
+  [[lein-monolith "1.3.3-SNAPSHOT"]
    [lein-pprint "1.2.0"]]
 
   :dependencies

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-monolith "1.3.2-SNAPSHOT"
+(defproject lein-monolith "1.3.2"
   :description "Leiningen plugin for managing subrojects within a monorepo."
   :url "https://github.com/amperity/lein-monolith"
   :license {:name "Apache License 2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-monolith "1.3.2"
+(defproject lein-monolith "1.3.3-SNAPSHOT"
   :description "Leiningen plugin for managing subrojects within a monorepo."
   :url "https://github.com/amperity/lein-monolith"
   :license {:name "Apache License 2.0"

--- a/src/lein_monolith/dependency.clj
+++ b/src/lein_monolith/dependency.clj
@@ -93,14 +93,28 @@
 
 ;; ## Dependency Graphs
 
+(defn- collect-dependencies
+  "Merges the project's top-level dependencies with all dependencies listed in
+  the project's profiles to ensure the project has the proper dependency closure
+  for compilation ordering."
+  [project]
+  (->>
+    project
+    (:profiles)
+    (vals)
+    (cons project)
+    (mapcat :dependencies)
+    (map (comp condense-name first))
+    (set)))
+
+
 (defn dependency-map
   "Converts a map of project names to definitions into a map of project names
   to sets of projects that node depends on."
   [projects]
   (->>
     (vals projects)
-    (map #(set (map (comp condense-name first)
-                    (:dependencies %))))
+    (map collect-dependencies)
     (zipmap (keys projects))))
 
 

--- a/test/lein_monolith/dependency_test.clj
+++ b/test/lein_monolith/dependency_test.clj
@@ -44,6 +44,10 @@
                    foo/d {:dependencies [[foo/b "1.0.0"]
                                          [foo/c "1.0.0"]]}}]
     (is (= '{foo/a #{}, foo/b #{foo/a}, foo/c #{foo/a}, foo/d #{foo/b foo/c}}
+           (dep/dependency-map projects))))
+  (let [projects '{foo/a {:dependencies []}
+                   foo/b {:dependencies [] :profiles {:test {:dependencies [[foo/a]]}}}}]
+    (is (= `{foo/a #{}, foo/b #{foo/a}}
            (dep/dependency-map projects)))))
 
 


### PR DESCRIPTION
Previously, if you declared a profile dependency in a project, that
dependency wouldn't be used in `lein monolith` dependency ordering
calculations, which could cause compilation errors when building
everything using that profile.

This updates the dependency calculation logic to include all profile
dependencies when calculating a project's dependency closure.

Fixes #51.