### PR TITLE
Always print each errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-...
+### Fixed
+- When an exception is thrown during an `each :endure` iteration, the stack
+  trace is printed immediately instead of swallowing the error.
 
 ## [1.3.2] - 2019-10-21
 

--- a/src/lein_monolith/task/each.clj
+++ b/src/lein_monolith/task/each.clj
@@ -1,6 +1,7 @@
 (ns lein-monolith.task.each
   (:require
     [clojure.java.io :as io]
+    [clojure.stacktrace :as cst]
     [clojure.string :as str]
     [lein-monolith.color :refer [colorize]]
     [lein-monolith.config :as config]
@@ -282,7 +283,12 @@
             (lein/warn (format "\n%s %s\n"
                                (colorize [:bold :red] "Resume with:")
                                (str/join " " resume-args)))))
-        (when-not (:endure opts)
+        (if (:endure opts)
+          (lein/warn (format "\n%s: %s\n%s"
+                             (colorize [:bold :red] "ERROR")
+                             (ex-message ex)
+                             (with-out-str
+                               (cst/print-cause-trace ex))))
           (throw ex))
         (assoc @results :success false, :error ex))
       (finally


### PR DESCRIPTION
When an exception is thrown during an `each :endure` iteration, right now we mark the project as failed and save the exception under an `:error` key, but nothing ever actually surfaced what the exception was. This change now prints the stack trace immediately when the error occurs if we're inside an `:endure`.