### PR TITLE
Log exceptions thrown in `each :output` runs

### DIFF
--- a/src/lein_monolith/task/each.clj
+++ b/src/lein_monolith/task/each.clj
@@ -236,6 +236,13 @@
         (binding [*task-file-output* file-output-stream]
           (with-redefs [leiningen.core.eval/sh run-with-output]
             (apply-subproject-task monolith subproject task)))
+        (catch Exception ex
+          (.write file-output-stream
+                  (.getBytes (format "\nERROR: %s\n%s"
+                                     (ex-message ex)
+                                     (with-out-str
+                                       (cst/print-cause-trace ex)))))
+          (throw ex))
         (finally
           ; Write task footer
           (.write file-output-stream


### PR DESCRIPTION
Currently, if a `lein monolith each :output ,,,` task throws an exception, the exception is not recorded in the task's output file (it is only recorded in the overall output). This starts recording the exception to the task's output file as well.