### PR TITLE
Resolve do subtasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Fixed
+- When an exception is thrown during an `each :endure` iteration, the stack
+  trace is printed immediately instead of swallowing the error.
 - When an exception is thrown during an `each :output` iteration, the stack
   trace is printed in the output file in addition to the combined output.
   [#56](https://github.com/amperity/lein-monolith/pull/56)
-
-### Fixed
-- When an exception is thrown during an `each :endure` iteration, the stack
-  trace is printed immediately instead of swallowing the error.
+- Subtasks of `do` are resolved before parallel execution, which should ensure
+  they are fully loaded before they are called.
 
 ## [1.3.2] - 2019-10-21
 

--- a/src/lein_monolith/task/each.clj
+++ b/src/lein_monolith/task/each.clj
@@ -323,7 +323,6 @@
     ;; A 'do' task pulls in other tasks, so also resolve them.
     (when (= "do" task)
       (doseq [[subtask & args] (lein-do/group-args (rest task+args))]
-        (prn ::resolve-tasks subtask args)
         (lein/resolve-task subtask)))))
 
 


### PR DESCRIPTION
We've been seeing some strange errors in our builds occasionally, where leiningen will complain about the wrong number of arguments to a task:
```
clojure.lang.ExceptionInfo: Wrong number of arguments to test task. 
Expected 
{:exit-code 1, :suppress-msg false}
```
The blank message here indicates that the task has a nil `arglist`, which is suspicious since the `test` task definitely does accept arguments. This feels like a load-order problem, and I noticed that this seems to only happen when using `do`.

There's a current bit of code that resolves the task you're about to apply, but it would only resolve `do`, not `check` and `test` in this example. Now if the first task is `do`, we also go and resolve all of the subtasks. This is isn't really scalable to _every_ higher-order task, but we can support the ones out-of-the-box in leiningen. `with-profile` might also be good to support if we see issues there.