### PR TITLE
Show all deps subtask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Prevent a potential race condition when combining the `:parallel` and
   `:output` options in the `each` subtask.
 
+### Added
+- New `deps` subtask supports listing all project dependencies in the monorepo.
+  The output should be suitable for other tooling to consume.
+
 ## [1.3.2] - 2019-10-21
 
 ### Fixed

--- a/src/lein_monolith/task/info.clj
+++ b/src/lein_monolith/task/info.clj
@@ -64,6 +64,23 @@
         (dep/select-dependency dep-name coords)))))
 
 
+(defn deps
+  "Print a list of subprojects and the (internal) projects they depend on.
+  Targeting options may be used to scope down the projects listed."
+  [project opts]
+  (let [[monolith subprojects] (u/load-monolith! project)
+        targets (target/select monolith subprojects opts)
+        dependencies (dep/dependency-map subprojects)]
+    (doseq [project-name targets]
+      (doseq [dependency (get dependencies project-name)]
+        (when (if (contains? subprojects dependency)
+                (u/parse-bool (:internal opts "true"))
+                (u/parse-bool (:external opts "false")))
+          (if (:bare opts)
+            (printf "%s\t%s\n" project-name dependency)
+            (println (colorize :bold project-name) "->" dependency)))))))
+
+
 (defn deps-on
   "Print a list of subprojects which depend on the given package(s). Defaults
   to the current project if none are provided."

--- a/src/lein_monolith/task/util.clj
+++ b/src/lein_monolith/task/util.clj
@@ -1,6 +1,7 @@
 (ns lein-monolith.task.util
   "Utility functions for task code."
   (:require
+    [clojure.string :as str]
     [lein-monolith.config :as config]
     [leiningen.core.main :as lein]))
 
@@ -41,6 +42,16 @@
           :else
           (recur (assoc opts kw (vec (take arg-count (rest args))))
                  (drop (inc arg-count) args)))))))
+
+
+(defn parse-bool
+  "Parse a boolean option with some slack for human-friendliness."
+  [x]
+  (case (str/lower-case (str x))
+    ("true" "t" "yes" "y") true
+    ("false" "f" "no" "n") false
+    (throw (IllegalArgumentException.
+             (format "%s is not a valid boolean value" (pr-str x))))))
 
 
 (defn globalize-opts

--- a/src/leiningen/monolith.clj
+++ b/src/leiningen/monolith.clj
@@ -51,6 +51,24 @@
   (info/lint project (if (seq args) (opts-only {:deps 0} args) {:deps true})))
 
 
+(defn deps
+  "Print a list of subprojects and the (internal) projects they depend on.
+  Targeting options may be used to scope down the projects listed.
+
+  Options:
+    :internal <bool>   Whether to show dependencies on internal projects (default: true)
+    :external <bool>   Whether to show dependencies on external projects (default: false)
+    :bare              Only print the project names and dependencies, one per line
+    (targets)          Standard target selection options are supported"
+  [project args]
+  (let [opts (opts-only (assoc target/selection-opts
+                               :internal 1
+                               :external 1
+                               :bare 0)
+                        args)]
+    (info/deps project opts)))
+
+
 (defn deps-on
   "Print a list of subprojects which depend on the given package(s). Defaults
   to the current project if none are provided.
@@ -226,13 +244,14 @@
 
 (defn monolith
   "Tasks for working with Leiningen projects inside a monorepo."
-  {:subtasks [#'info #'lint #'deps-on #'deps-of #'graph
+  {:subtasks [#'info #'lint #'deps #'deps-on #'deps-of #'graph
               #'with-all #'each #'link #'unlink
               #'changed #'mark-fresh #'clear-fingerprints]}
   [project command & args]
   (case command
     "info"               (info project args)
     "lint"               (lint project args)
+    "deps"               (deps project args)
     "deps-on"            (deps-on project args)
     "deps-of"            (deps-of project args)
     "graph"              (graph project args)


### PR DESCRIPTION
Adds a new info subtask to print out the full set of dependency edges of subprojects in the monorepo. By default this shows the internal dependencies only, but can also show external deps or a targeted subset of the project deps using the options.

```
% lein monolith deps
example/app-a -> example/lib-b
example/app-a -> example/lib-a
example/lib-b -> example/lib-a

% lein monolith deps :internal false :external true :bare
example/app-a   org.clojure/clojure
example/app-a   commons-io
example/lib-b   org.clojure/clojure
example/lib-a   org.clojure/clojure
```
