### PR TITLE
Ensure resume suggestions are shell-escaped

### DIFF
--- a/src/lein_monolith/task/each.clj
+++ b/src/lein_monolith/task/each.clj
@@ -306,11 +306,13 @@
       (assoc @results :success true)
       (catch Exception ex
         (when-not (or (:parallel opts) (:endure opts))
-          (let [resume-args (concat
-                              ["lein monolith each"]
-                              (opts->args (dissoc opts :start))
-                              [:start target]
-                              (:task ctx))]
+          (let [resume-args (into
+                              ["lein" "monolith" "each"]
+                              (map u/shell-escape)
+                              (concat
+                                (opts->args (dissoc opts :start))
+                                [:start target]
+                                (:task ctx)))]
             (lein/warn (format "\n%s %s\n"
                                (colorize [:bold :red] "Resume with:")
                                (str/join " " resume-args)))))

--- a/src/lein_monolith/task/util.clj
+++ b/src/lein_monolith/task/util.clj
@@ -6,6 +6,19 @@
     [leiningen.core.main :as lein]))
 
 
+(defn shell-escape
+  "Escape the provided argument for use in a shell."
+  [arg]
+  (let [s (if (string? arg)
+            arg
+            (pr-str arg))]
+    (if (or (str/includes? s " ")
+            (str/includes? s "'")
+            (str/includes? s "\""))
+      (str \' (str/escape s {\' "\\'"}) \')
+      s)))
+
+
 (defn parse-kw-args
   "Given a sequence of string arguments, parse out expected keywords. Returns
   a vector with a map of keywords to values (or `true` for flags) followed by

--- a/test/lein_monolith/task/util_test.clj
+++ b/test/lein_monolith/task/util_test.clj
@@ -4,6 +4,16 @@
     [lein-monolith.task.util :as u]))
 
 
+(deftest shell-escaping
+  (is (= "nil" (u/shell-escape nil)))
+  (is (= "123" (u/shell-escape 123)))
+  (is (= "foo" (u/shell-escape "foo")))
+  (is (= ":abc" (u/shell-escape :abc)))
+  (is (= "'[123 true]'" (u/shell-escape [123 true])))
+  (is (= "'\\'foo'" (u/shell-escape "'foo")))
+  (is (= "'\"xyz\"'" (u/shell-escape "\"xyz\""))))
+
+
 (deftest kw-arg-parsing
   (testing "empty arguments"
     (is (= [{} []]


### PR DESCRIPTION
Fixes #27 

## Testing

I induced a failure in the example projects and ran an iteration over them:

```
% lein monolith each do test, shell echo 'foo bar baz'
Applying do test, shell echo foo bar baz to 3 subprojects...

...

Resume with: lein monolith each :start example/lib-b do test, shell echo 'foo bar baz'

Completed example/lib-b (2/3) in 0:01.113
Tests failed.
```