### PR TITLE
Better dependency linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- The `lint` task now only considers dependency names and versions for
+  detecting conflicts, which should improve the signal-to-noise ratio.
+  [#73](https://github.com/amperity/lein-monolith/pull/73)
+
 ### Fixed
 - When the `each` task provides a command to resume execution, the arguments
   will be properly quoted for shells.

--- a/src/lein_monolith/task/info.clj
+++ b/src/lein_monolith/task/info.clj
@@ -59,7 +59,7 @@
       (doseq [[dep-name coords] (->> (vals subprojects)
                                      (mapcat dep/sourced-dependencies)
                                      (group-by first))]
-        (dep/select-dependency dep-name coords)))))
+        (dep/lint-dependency dep-name coords)))))
 
 
 (defn deps

--- a/test/lein_monolith/dependency_test.clj
+++ b/test/lein_monolith/dependency_test.clj
@@ -28,14 +28,14 @@
       (is (= 'example/bar (dep/resolve-name projects 'bar)))
       (is (= 'baz/foo (dep/resolve-name projects 'baz/foo)))
       (is (= 'example/baz (dep/resolve-name projects 'baz)))))
-  (testing "unscope-coord"
-    (is (= '[example/foo "1.0"] (dep/unscope-coord '[example/foo "1.0"])))
-    (is (= '[example/bar "0.5.0" :exclusions [foo]]
-           (dep/unscope-coord '[example/bar "0.5.0" :exclusions [foo]])))
-    (is (= '[example/bar "0.5.0" :exclusions [foo]]
-           (dep/unscope-coord '[example/bar "0.5.0" :exclusions [foo] :scope :test])))
+  (testing "clean-coord"
+    (is (= '[example/foo "1.0"] (dep/clean-coord '[example/foo "1.0"])))
+    (is (= '[example/bar "0.5.0"]
+           (dep/clean-coord '[example/bar "0.5.0" :exclusions [foo]])))
+    (is (= '[example/bar "0.5.0"]
+           (dep/clean-coord '[example/bar "0.5.0" :exclusions [foo] :scope :test])))
     (is (= '[example/baz "0.1.0-SNAPSHOT"]
-           (dep/unscope-coord '[example/baz "0.1.0-SNAPSHOT" :scope :test]))))
+           (dep/clean-coord '[example/baz "0.1.0-SNAPSHOT" :scope :test]))))
   (testing "source-metadata"
     (is (nil? (dep/dep-source [:foo "123"])))
     (is (= [:foo "123"] (dep/with-source [:foo "123"] 'example/bar)))


### PR DESCRIPTION
A minor improvement which updates the `lein monolith lint` command. This now ignores _all_ modifiers on the dependency coordinates, instead of just stopping when it sees `:scope`. It does still think of `[foo/bar nil]` as different from `[foo/bar "version"]`, even if there's a managed dependency on `"version"`, but this seems appropriate since it does indicate that bumping the managed dependency won't update some of the subprojects.