### PR TITLE
Fix parallel inherited aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   will be properly quoted for shells.
   [#27](https://github.com/amperity/lein-monolith/issues/27)
   [#72](https://github.com/amperity/lein-monolith/pull/72)
+- When `each` is used with `:parallel`, task aliases are now correctly resolved
+  before iteration starts.
+  [#36](https://github.com/amperity/lein-monolith/issues/36)
+  [#74](https://github.com/amperity/lein-monolith/pull/74)
 
 
 ## [1.5.0] - 2020-09-17

--- a/example/libs/lib-b/project.clj
+++ b/example/libs/lib-b/project.clj
@@ -1,5 +1,6 @@
 (defproject example/lib-b "0.2.0"
   :description "Example lib depending on lib-a."
+  :monolith/inherit [:aliases]
 
   :dependencies
   [[example/lib-a "1.0.0"]

--- a/example/project.clj
+++ b/example/project.clj
@@ -1,6 +1,10 @@
 (defproject example/all "MONOLITH"
   :description "Overarching example project."
 
+  :aliases
+  {"version+" ["version"]
+   "version++" ["version+"]}
+
   :plugins
   [[lein-monolith "1.5.1-SNAPSHOT"]
    [lein-pprint "1.2.0"]]
@@ -14,7 +18,8 @@
 
   :monolith
   {:inherit
-   [:test-selectors
+   [:aliases
+    :test-selectors
     :env]
 
    :inherit-leaky


### PR DESCRIPTION
When `lein-monolith each` is used with the `:parallel` option, it does some work up-front to ensure all the tasks referenced are fully resolved and loaded before execution begins. This is done in order to avoid concurrent namespace loads, which is known to cause issues (see issue #15 for details). However, the current implementation does not resolve aliases to _real_ tasks before it tries to load them, leading to confusing behavior when you're trying to use a task alias in parallel.

Fixes #36 