### PR TITLE
Save test results for CircleCI to display

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,9 @@ jobs:
             - v1-test-
       - run: lein deps
       - run: lein check
-      - run: lein test
+      - run: lein with-profile +ci test2junit
+      - store_test_results:
+          path: test-results
       - save_cache:
           key: v1-test-{{ checksum "project.clj" }}
           paths:

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ pom.xml
 pom.xml.asc
 *.class
 *.jar
+test-results
+build.xml

--- a/project.clj
+++ b/project.clj
@@ -18,5 +18,11 @@
    :ignore-ns #{clojure manifold}}
 
   :profiles
-  {:dev {:plugins [[lein-cloverage "1.0.9"]]
-         :dependencies [[org.clojure/clojure "1.9.0"]]}})
+  {:dev
+   {:plugins [[lein-cloverage "1.0.9"]]
+    :dependencies [[org.clojure/clojure "1.9.0"]]}
+
+   :ci
+   {:plugins [[test2junit "1.4.2"]]
+    :test2junit-silent true
+    :test2junit-output-dir "test-results/clojure.test"}})


### PR DESCRIPTION
Adds a `:ci` profile with [test2junit](https://github.com/ruedigergad/test2junit) configuration and updates CircleCI configuration to store the test results. Gives some nice output on that tests tab :)