### PR TITLE
Fix each composite profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   will be properly quoted for shells.
   [#27](https://github.com/amperity/lein-monolith/issues/27)
   [#72](https://github.com/amperity/lein-monolith/pull/72)
+- The `each` task is now compatible with composite profiles.
+  [#29](https://github.com/amperity/lein-monolith/issues/29)
+  [#77](https://github.com/amperity/lein-monolith/pull/77)
 
 
 ## [1.5.0] - 2020-09-17

--- a/example/apps/app-a/project.clj
+++ b/example/apps/app-a/project.clj
@@ -10,6 +10,6 @@
    [example/lib-b "MONOLITH-SNAPSHOT"]]
 
   :profiles
-  {:shared {:source-paths ["/dev/null"]}
+  {:shared {:source-paths ["bench"]}
    :dev [:shared {:dependencies [[clj-stacktrace "0.2.8"]]}]
    :uberjar [:shared {:dependencies [[commons-net "3.6"]]}]})

--- a/example/apps/app-a/project.clj
+++ b/example/apps/app-a/project.clj
@@ -1,10 +1,15 @@
-(defproject example/app-a "0.5.0"
+(defproject example/app-a "MONOLITH-SNAPSHOT"
   :description "Example project with internal and external dependencies."
   :monolith/inherit true
   :deployable true
 
   :dependencies
-  [[commons-io "2.5"]
-   [example/lib-a "1.0.0"]
-   [example/lib-b "0.2.0"]
-   [org.clojure/clojure "1.8.0"]])
+  [[org.clojure/clojure "1.10.1"]
+   [commons-io "2.5"]
+   [example/lib-a "MONOLITH-SNAPSHOT"]
+   [example/lib-b "MONOLITH-SNAPSHOT"]]
+
+  :profiles
+  {:shared {:source-paths ["/dev/null"]}
+   :dev [:shared {:dependencies [[clj-stacktrace "0.2.8"]]}]
+   :uberjar [:shared {:dependencies [[commons-net "3.6"]]}]})

--- a/example/libs/lib-a/project.clj
+++ b/example/libs/lib-a/project.clj
@@ -1,8 +1,8 @@
-(defproject example/lib-a "1.0.0"
+(defproject example/lib-a "MONOLITH-SNAPSHOT"
   :description "Example library with no internal dependencies."
   :monolith/inherit true
 
   :pedantic? :abort
 
   :dependencies
-  [[org.clojure/clojure "1.8.0"]])
+  [[org.clojure/clojure "1.10.1"]])

--- a/example/libs/lib-b/project.clj
+++ b/example/libs/lib-b/project.clj
@@ -1,6 +1,6 @@
-(defproject example/lib-b "0.2.0"
+(defproject example/lib-b "MONOLITH-SNAPSHOT"
   :description "Example lib depending on lib-a."
 
   :dependencies
-  [[example/lib-a "1.0.0"]
-   [org.clojure/clojure "1.8.0"]])
+  [[org.clojure/clojure "1.10.1"]
+   [example/lib-a "MONOLITH-SNAPSHOT"]])

--- a/example/project.clj
+++ b/example/project.clj
@@ -8,6 +8,9 @@
   :dependencies
   [[org.clojure/clojure "1.10.1"]]
 
+  :managed-dependencies
+  [[amperity/greenlight "0.6.0"]]
+
   :test-selectors
   {:unit (complement :integration)
    :integration :integration}

--- a/src/lein_monolith/plugin.clj
+++ b/src/lein_monolith/plugin.clj
@@ -148,4 +148,4 @@
   (let [mw-sym 'lein-monolith.plugin/middleware]
     (if (some #{mw-sym} (:middleware project))
       project
-      (update project :middleware (fnil into []) [mw-sym]))))
+      (update project :middleware (fnil conj []) mw-sym))))

--- a/src/lein_monolith/plugin.clj
+++ b/src/lein_monolith/plugin.clj
@@ -139,3 +139,13 @@
         (reduce-kv add-active-profile project profiles)))
     ; Normal project, don't activate.
     project))
+
+
+(defn add-middleware
+  "Update the given project to include the plugin middleware. Appends the
+  middleware symbol if it is not already present."
+  [project]
+  (let [mw-sym 'lein-monolith.plugin/middleware]
+    (if (some #{mw-sym} (:middleware project))
+      project
+      (update project :middleware (fnil into []) [mw-sym]))))


### PR DESCRIPTION
This bug turns out to be a really gnarly interaction deep inside Leiningen that I still don't fully understand, but for some reason supplying multiple profiles to `init-project` adds a number of metadata profiles with `:aliases nil` entries here:
https://github.com/technomancy/leiningen/blob/94a1b2e6c9cd2028400c2e8abb4797d3f4116ef1/leiningen-core/src/leiningen/core/project.clj#L1019-L1022

This in turn causes the `meta-merge` call in `apply-profiles` to try merging `{:aliases nil}` into the `:uberjar` profile:
https://github.com/technomancy/leiningen/blob/94a1b2e6c9cd2028400c2e8abb4797d3f4116ef1/leiningen-core/src/leiningen/core/project.clj#L621

When `:uberjar` is a map, this works okay because the nil is a no-op. When it's a composite profile though, this tries to merge the map into the vector, which winds up coercing it into a sequence. The main difference in how these profiles get activated is that `each` injects the profiles directly by supplying it as a default vs a subproject where it is loaded by metadata. Since the subproject case works, try injecting the _middleware_ instead of the profiles and let the machinery operate the same way there.

Fixes #29 