### PR TITLE
Add :silent option to each task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   [#36](https://github.com/amperity/lein-monolith/issues/36)
   [#74](https://github.com/amperity/lein-monolith/pull/74)
 
+### Added
+- The `each` task supports a new `:silent` option, which will suppress task
+  output for successful projects. This can be useful in large CI builds where
+  the output is only consulted in the event of failure.
+  [#37](https://github.com/amperity/lein-monolith/issues/37)
+  [#81](https://github.com/amperity/lein-monolith/pull/81)
+
 
 ## [1.5.0] - 2020-09-17
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ In addition to targeting options, `each` accepts:
   is useful in situations such as CI tests, where you don't want a failure to
   halt iteration.
 - `:report` show a detailed timing report after the tasks finish executing.
+- `:silent` suppress task output for successful projects.
 - `:output` path to a directory to save individual build output in.
 
 #### Incremental Builds

--- a/src/lein_monolith/task/each.clj
+++ b/src/lein_monolith/task/each.clj
@@ -212,7 +212,8 @@
             (.kill ^RevivableInputStream System/in)
             (.join pump-in)
             (.resurrect ^RevivableInputStream System/in))
-          (.flush ^OutputStream *task-file-output*)
+          (when *task-file-output*
+            (.flush ^OutputStream *task-file-output*))
           exit-value)))))
 
 

--- a/src/lein_monolith/task/util.clj
+++ b/src/lein_monolith/task/util.clj
@@ -79,6 +79,14 @@
       (:downstream opts) (update :downstream-of conj (:name project)))))
 
 
+(defn stopwatch
+  "Construct a timer which will contain the number of milliseconds elapsed
+  between its creation and when it is dereferenced."
+  []
+  (let [start (System/nanoTime)]
+    (delay (/ (- (System/nanoTime) start) 1e6))))
+
+
 (defn human-duration
   "Renders a duration in milliseconds in hour:minute:second.ms format."
   [duration]

--- a/src/leiningen/monolith.clj
+++ b/src/leiningen/monolith.clj
@@ -149,6 +149,7 @@
     :parallel <threads>        Run tasks in parallel across a fixed thread pool.
     :endure                    Continue executing the task even if some subprojects fail.
     :report                    Print a detailed timing report after running tasks.
+    :silent                    Don't print project output unless the task fails.
     :output <path>             Save each project's individual output in the given directory.
 
   Targeting Options:

--- a/src/leiningen/monolith.clj
+++ b/src/leiningen/monolith.clj
@@ -146,11 +146,11 @@
   project to resume from.
 
   General Options:
-    :parallel <threads>        Run tasks in parallel across a fixed thread pool.
-    :endure                    Continue executing the task even if some subprojects fail.
-    :report                    Print a detailed timing report after running tasks.
-    :silent                    Don't print project output unless the task fails.
-    :output <path>             Save each project's individual output in the given directory.
+    :parallel <threads>     Run tasks in parallel across a fixed thread pool.
+    :endure                 Continue executing the task even if some subprojects fail.
+    :report                 Print a detailed timing report after running tasks.
+    :silent                 Don't print task output unless a subproject fails.
+    :output <path>          Save each project's individual output in the given directory.
 
   Targeting Options:
     :in <names>             Add the named projects directly to the targets.


### PR DESCRIPTION
This change adds a new `:silent` option to the `each` task. When set, the output of projects is captured instead of streamed to the standard out and error streams. If a project fails, the output is then printed in full. This has two nice properties; first, in large CI builds users often only care about _failing_ project output, but one failing project out of two hundred can be difficult to find. Second, this change introduces an output lock, so multiple concurrent project failures will not be interleaved.

This functionality is orthogonal to the `:output <dir>` option; successful project output is still logged to the output file even if it is suppressed with `:silent`.

Fixes #37 