### PR TITLE
Optimize each by manually applying middleware

### DIFF
--- a/src/lein_monolith/plugin.clj
+++ b/src/lein_monolith/plugin.clj
@@ -159,14 +159,14 @@
    (middleware project nil))
   ([project monolith]
    (if (or (not (:monolith/inherit project)) (:monolith/active (meta project)))
-     ;; Normal or already activated project, don't activate.
+     ;; Normal project or already activated monolith subproject, don't activate.
      project
-     ;; Monolith subproject, add inherited profile.
+     ;; Monolith subproject has not yet been activated, add inherited profile.
      (if (some (fn this-profile-active?
                  [entry]
                  (profile-active? project (first entry)))
                profile-config)
-       ;; Already activated, return project.
+       ;; One or more profiles already present, return project.
        (do (lein/debug "One or more inherited profiles are already active!")
            project)
        ;; Find monolith metaproject and generate profile.

--- a/src/lein_monolith/plugin.clj
+++ b/src/lein_monolith/plugin.clj
@@ -158,8 +158,9 @@
   ([project]
    (middleware project nil))
   ([project monolith]
-   (if (and (:monolith/inherit project)
-            (not (contains? (meta project) :monolith/active)))
+   (if (or (not (:monolith/inherit project)) (:monolith/active (meta project)))
+     ;; Normal or already activated project, don't activate.
+     project
      ;; Monolith subproject, add inherited profile.
      (if (some (fn this-profile-active?
                  [entry]
@@ -172,9 +173,7 @@
        (let [monolith (or monolith (config/find-monolith! project))
              profiles (build-inherited-profiles monolith project)
              with-profiles (reduce-kv add-active-profile project profiles)]
-         (vary-meta with-profiles assoc :monolith/active true)))
-     ;; Normal project, don't activate.
-     project)))
+         (vary-meta with-profiles assoc :monolith/active true))))))
 
 
 (defn- add-middleware


### PR DESCRIPTION
each already has a reference to the monolith in its context. By manually applying the middleware after inserting its symbol and adding a metadata key that identifies already activated monoliths, the number of project reads and initializations can be reduced.