### PR TITLE
Update merged profile paths

### DIFF
--- a/src/lein_monolith/plugin.clj
+++ b/src/lein_monolith/plugin.clj
@@ -230,7 +230,7 @@
   absolutizes any paths in the subproject that may be relative."
   [monolith [_project-name subproject]]
   (-> subproject
-      (project/project-with-profiles (:profiles subproject))
+      (project/project-with-profiles)
       (project/init-profiles (:active-profiles (meta monolith)))
       (middleware monolith)
       (project/absolutize-paths)))

--- a/src/leiningen/monolith.clj
+++ b/src/leiningen/monolith.clj
@@ -109,6 +109,13 @@
                args)))
 
 
+(defn- assoc-empty-displaceable
+  "Associate a given key with an empty, ^:displace-able version of its value,
+  meant to be suberseded by a value from an incoming profile."
+  [proj k v]
+  (assoc proj k (with-meta (empty v) {:displace true})))
+
+
 (defn ^:higher-order with-all
   "Apply the given task with a merged set of dependencies, sources, and tests
   from all the internal projects.
@@ -123,11 +130,7 @@
         [monolith subprojects] (u/load-monolith! project)
         targets (target/select monolith subprojects opts)
         profile (plugin/merged-profile monolith (select-keys subprojects targets))
-        project (reduce-kv
-                  (fn remove-replace-meta
-                    [proj k _v]
-                    (update proj k vary-meta dissoc :replace))
-                  project profile)]
+        project (reduce-kv assoc-empty-displaceable project profile)]
     (lein/apply-task
       task
       (plugin/add-active-profile project :monolith/all profile)

--- a/test/lein_monolith/monolith_test.clj
+++ b/test/lein_monolith/monolith_test.clj
@@ -41,17 +41,23 @@
 
 
 (deftest with-all-test
-  (is (= ["apps/app-a/resources"
-          "dev-resources"
+  (is (= [['lein-monolith.example/lib-a "MONOLITH-SNAPSHOT"]
+          ['lein-monolith.example/app-a "MONOLITH-SNAPSHOT"]
+          ['lein-monolith.example/lib-b "MONOLITH-SNAPSHOT"]]
+         (read-pprint-output :dependencies)))
+
+  (is (= ["apps/app-a/dev-resources"
+          "apps/app-a/resources"
+          "libs/lib-a/dev-resources"
           "libs/lib-a/resources"
-          "libs/lib-b/resources"
-          "resources"]
+          "libs/lib-b/dev-resources"
+          "libs/lib-b/resources"]
          (relativize-pprint-output :resource-paths)))
 
-  (is (= ["apps/app-a/src"
+  (is (= ["apps/app-a/bench"
+          "apps/app-a/src"
           "libs/lib-a/src"
-          "libs/lib-b/src"
-          "src"]
+          "libs/lib-b/src"]
          (relativize-pprint-output :source-paths)))
 
   (is (= ["apps/app-a/test/integration"
@@ -59,7 +65,5 @@
           "libs/lib-a/test/integration"
           "libs/lib-a/test/unit"
           "libs/lib-b/test/integration"
-          "libs/lib-b/test/unit"
-          "test/integration"
-          "test/unit"]
+          "libs/lib-b/test/unit"]
          (relativize-pprint-output :test-paths))))


### PR DESCRIPTION
Removes monolith project paths and dependencies from the output, and ensures that profiles active in the monolith are activated in subprojects before reading and absolutizing paths.

As discussed in #75.