### PR TITLE
Recursive project search

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -12,6 +12,8 @@ direct subproject directory (containing a `project.clj` file) such as
 `apps/app-a`, or end with a wildcard `*` to indicate that all child directories
 should be searched for projects, like `libs/*`. Note that this only works with a
 single level of wildcard matching at the end of the path.
+If you would like to search recursively you can indicate that using `lib/**`
+and it will search for all subdirectories containing a `project.clj` file.
 
 ## Config Inheritance
 

--- a/example/libs/subdir/lib-c/.gitignore
+++ b/example/libs/subdir/lib-c/.gitignore
@@ -1,0 +1,9 @@
+/target
+/classes
+/checkouts
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+/.lein-*
+/.nrepl-port

--- a/example/libs/subdir/lib-c/project.clj
+++ b/example/libs/subdir/lib-c/project.clj
@@ -1,0 +1,7 @@
+(defproject lein-monolith.example/lib-c "MONOLITH-SNAPSHOT"
+  :description "Example lib depending on lib-a."
+  :monolith/inherit [:aliases]
+
+  :dependencies
+  [[org.clojure/clojure "1.10.1"]
+   [lein-monolith.example/lib-a "MONOLITH-SNAPSHOT"]])

--- a/example/libs/subdir/lib-c/src/lib_c/core.clj
+++ b/example/libs/subdir/lib-c/src/lib_c/core.clj
@@ -1,0 +1,7 @@
+(ns lib-c.core)
+
+
+(defn foo
+  "I don't do a whole lot."
+  [x]
+  (println x "Hello, World!"))

--- a/example/libs/subdir/lib-c/src/lib_c/lib_b/core_test.clj
+++ b/example/libs/subdir/lib-c/src/lib_c/lib_b/core_test.clj
@@ -1,0 +1,9 @@
+(ns lib-c.core-test
+  (:require
+    [clojure.test :refer :all]
+    [lib-c.core :refer :all]))
+
+
+(deftest b-code-test
+  (testing "FIXME, I fail."
+    (is false)))

--- a/example/libs/subdir/lib-c/src/lib_c/lib_b/core_test.clj
+++ b/example/libs/subdir/lib-c/src/lib_c/lib_b/core_test.clj
@@ -1,9 +1,0 @@
-(ns lib-c.core-test
-  (:require
-    [clojure.test :refer :all]
-    [lib-c.core :refer :all]))
-
-
-(deftest b-code-test
-  (testing "FIXME, I fail."
-    (is false)))

--- a/example/project.clj
+++ b/example/project.clj
@@ -48,7 +48,7 @@
 
    :project-dirs
    ["apps/app-a"
-    "libs/*"
+    "libs/**"
     "not-found"]}
 
   :env

--- a/example/project.clj
+++ b/example/project.clj
@@ -47,7 +47,7 @@
     :unstable #(= (first (:version %)) \0)}
 
    :project-dirs
-   ["apps/app-a"
+   ["apps/*"
     "libs/**"
     "not-found"]}
 

--- a/src/lein_monolith/config.clj
+++ b/src/lein_monolith/config.clj
@@ -82,16 +82,19 @@
 
 ;; ## Subproject Configuration
 
-(defn- is-project-dir?
+(defn- project-dir?
+  "Given a directory returns true if it contains a `project.clj` file"
   [dir]
   (.exists (io/file dir "project.clj")))
 
 
 (defn- all-projects
+  "Given a directory recursively search for all sub directories that contain
+  a `project.clj` file and return that list."
   [dir]
   (let [subdirs (->> (.listFiles dir)
                      (filter #(.isDirectory ^File %)))
-        grouped (group-by is-project-dir? subdirs)
+        grouped (group-by project-dir? subdirs)
         top-projects (get grouped true)
         all-subdir-project (mapcat all-projects (get grouped false))]
     (concat top-projects all-subdir-project)))

--- a/test/example-tests.sh
+++ b/test/example-tests.sh
@@ -30,6 +30,7 @@ test_monolith lint
 test_monolith deps
 test_monolith deps-of app-a
 test_monolith deps-on lib-a
+test_monolith deps-of lib-c
 test_monolith with-all pprint :dependencies :source-paths :test-paths
 test_monolith each pprint :version
 test_monolith each :in lib-a pprint :root :compile-path

--- a/test/lein_monolith/monolith_test.clj
+++ b/test/lein_monolith/monolith_test.clj
@@ -45,12 +45,14 @@
           "dev-resources"
           "libs/lib-a/resources"
           "libs/lib-b/resources"
+          "libs/subdir/lib-c/resources"
           "resources"]
          (relativize-pprint-output :resource-paths)))
 
   (is (= ["apps/app-a/src"
           "libs/lib-a/src"
           "libs/lib-b/src"
+          "libs/subdir/lib-c/src"
           "src"]
          (relativize-pprint-output :source-paths)))
 
@@ -60,6 +62,8 @@
           "libs/lib-a/test/unit"
           "libs/lib-b/test/integration"
           "libs/lib-b/test/unit"
+          "libs/subdir/lib-c/test/integration"
+          "libs/subdir/lib-c/test/unit"
           "test/integration"
           "test/unit"]
          (relativize-pprint-output :test-paths))))


### PR DESCRIPTION
This PR introduce a `/**` notation for `:project-dirs` to recursively search for sub projects.

We have a very big monorepo. 
Its size is so big now that we would like to support a hierarchy in those sub projects.
Instead of manually writing all sub directories, I would like to search recursively.

Typically we already have `:project-dirs  ["lib/*" "services/*"]` and we would like to split some services but not have a flat organisation so `:project-dirs ["lib/*" "services/**"]`. This way we could take a service `foo`  split the code in 10 sub projects under the `foo` directory (that will no longer be a project directory).
