### PR TITLE
Include Java source files in project fingerprints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   a double-wildcard `.../**` syntax.
   [#85](https://github.com/amperity/lein-monolith/pull/85)
 
+### Fixed
+- Fingerprinting will now correctly track Java files as project source files.
+  [#87](https://github.com/amperity/lein-monolith/pull/87)
+
 
 ## [1.6.1] - 2020-10-09
 

--- a/src/lein_monolith/task/fingerprint.clj
+++ b/src/lein_monolith/task/fingerprint.clj
@@ -96,7 +96,7 @@
   (->> (concat
          [project]
          (vals (:profiles project)))
-       (mapcat (juxt :source-paths :test-paths :resource-paths))
+       (mapcat (juxt :source-paths :java-source-paths :test-paths :resource-paths))
        (mapcat identity)
        (map (fn absolute-file
               [dir-str]


### PR DESCRIPTION
Simple fix -- add `:java-source-paths` to the list of file paths
to check when fingerprinting.