### PR TITLE
Bump dependency and ci tool versions and make linting fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,8 +19,8 @@ jobs:
           environment:
             CLJSTYLE_VERSION: 0.15.0
           command: |
-            wget https://github.com/greglook/cljstyle/releases/download/${CLJSTYLE_VERSION}/cljstyle_${CLJSTYLE_VERSION}_linux.tar.gz
-            tar -xzf cljstyle_${CLJSTYLE_VERSION}_linux.tar.gz
+            wget https://github.com/greglook/cljstyle/releases/download/${CLJSTYLE_VERSION}/cljstyle_${CLJSTYLE_VERSION}_linux.zip
+            unzip cljstyle_${CLJSTYLE_VERSION}_linux.zip
       - run:
           name: Check source formatting
           command: "./cljstyle check --report"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - run:
           name: Install cljstyle CLI
           environment:
-            CLJSTYLE_VERSION: 0.13.0
+            CLJSTYLE_VERSION: 0.15.0
           command: |
             wget https://github.com/greglook/cljstyle/releases/download/${CLJSTYLE_VERSION}/cljstyle_${CLJSTYLE_VERSION}_linux.tar.gz
             tar -xzf cljstyle_${CLJSTYLE_VERSION}_linux.tar.gz
@@ -32,9 +32,9 @@ jobs:
       - run:
           name: Install clj-kondo
           environment:
-            CLJ_KONDO_VERSION: 2020.09.09
+            CLJ_KONDO_VERSION: 2022.05.27
           command: |
-            wget https://github.com/borkdude/clj-kondo/releases/download/v${CLJ_KONDO_VERSION}/clj-kondo-${CLJ_KONDO_VERSION}-linux-amd64.zip
+            wget https://github.com/clj-kondo/clj-kondo/releases/download/v${CLJ_KONDO_VERSION}/clj-kondo-${CLJ_KONDO_VERSION}-linux-amd64.zip
             unzip clj-kondo-${CLJ_KONDO_VERSION}-linux-amd64.zip
       - run:
           name: Lint source code

--- a/.cljstyle
+++ b/.cljstyle
@@ -1,8 +1,8 @@
 ;; Clojure formatting rules
 ;; vim: filetype=clojure
-{:file-ignore #{"checkouts" "target"}
- :padding-lines 2
- :max-consecutive-blank-lines 3
- :single-import-break-width 30
- :indents {config/debug-profile [[:block 1]]
-           d/future-with [[:block 1]]}}
+{:files {:ignore #{"checkouts" "target"}},
+ :rules
+ {:indentation
+  {:indents
+   {config/debug-profile [[:block 1]], d/future-with [[:block 1]]}},
+  :blank-lines {:max-consecutive 3}}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 
 ## [Unreleased]
-
+- Bump dependency versions.
 
 ## [1.7.0] - 2021-06-11
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2016-2019 Amperity, Inc.
+Copyright 2016-2022 Amperity, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/example/project.clj
+++ b/example/project.clj
@@ -6,7 +6,7 @@
    "version++" ["version+"]}
 
   :plugins
-  [[lein-monolith "1.7.0"]
+  [[lein-monolith "1.7.1-SNAPSHOT"]
    [lein-pprint "1.2.0"]]
 
   :dependencies

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
   :deploy-branches ["master"]
 
   :dependencies
-  [[manifold "0.1.8"]
+  [[manifold "0.2.4"]
    [rhizome "0.2.9"]]
 
   :hiera
@@ -19,8 +19,8 @@
 
   :profiles
   {:dev
-   {:plugins [[lein-cloverage "1.2.1"]]
-    :dependencies [[org.clojure/clojure "1.10.1"]]}
+   {:plugins [[lein-cloverage "1.2.4"]]
+    :dependencies [[org.clojure/clojure "1.10.3"]]}
 
    :ci
    {:plugins [[test2junit "1.4.2"]]

--- a/src/lein_monolith/dependency.clj
+++ b/src/lein_monolith/dependency.clj
@@ -126,14 +126,14 @@
   (loop [result #{}
          queue (conj (clojure.lang.PersistentQueue/EMPTY) root)]
     (cond
-      ; Nothing left to process.
+      ;; Nothing left to process.
       (empty? queue) result
 
-      ; Already seen this node.
+      ;; Already seen this node.
       (contains? result (peek queue))
       (recur result (pop queue))
 
-      ; Add next set of dependencies.
+      ;; Add next set of dependencies.
       :else
       (let [node (peek queue)
             deps (dependencies node)]
@@ -152,14 +152,14 @@
     (loop [result #{}
            queue (conj (clojure.lang.PersistentQueue/EMPTY) root)]
       (cond
-        ; Nothing left to process.
+        ;; Nothing left to process.
         (empty? queue) result
 
-        ; Already seen this node, deps are either present or already queued.
+        ;; Already seen this node, deps are either present or already queued.
         (contains? result (peek queue))
         (recur result (pop queue))
 
-        ; Add next set of dependencies.
+        ;; Add next set of dependencies.
         :else
         (let [node (peek queue)
               consumers (deps-on node)]
@@ -180,20 +180,20 @@
                              path-set (set path)]
                          (mapcat (fn [v]
                                    (if (path-set v)
-                                     ; found the cycle
+                                     ;; found the cycle
                                      [(into []
-                                            ; drop non-cyclic prefix
+                                            ;; drop non-cyclic prefix
                                             (drop-while (complement #{v}))
                                             (conj path v))]
                                      (path->cycles
                                        (conj path v))))
                                  vs)))
         all-cycles (mapcat #(path->cycles [%]) (keys m))
-        ; remove duplicate cycles (that involve the same deps) -- like
-        ;   (into #{}
-        ;         (map (comp first val))
-        ;         (group-by set all-cycles))
-        ; but in a single pass.
+        ;; remove duplicate cycles (that involve the same deps) -- like
+        ;;   (into #{}
+        ;;         (map (comp first val))
+        ;;         (group-by set all-cycles))
+        ;; but in a single pass.
         [cycles-vecs _] (reduce (fn [[cycles-vecs cycle-sets] c]
                                   (let [cset (set c)]
                                     (if (cycle-sets cset)
@@ -223,8 +223,8 @@
                "|_|"])
     (str/join (map-indexed (fn [indent el]
                              (if (= indent (dec (count c)))
-                               ; draw:
-                               ;|___/
+                               ;; draw:
+                               ;; |___/
                                (str
                                  \|
                                  (str/join (repeat (max 1 (- indent 2)) \_))
@@ -245,8 +245,8 @@
   other words, earlier keys do not transitively depend on any later keys."
   ([m]
    (when (seq m)
-     ; Note that 'roots' here are keys which no other keys depend on, hence
-     ; should appear *later* in the sequence.
+     ;; Note that 'roots' here are keys which no other keys depend on, hence
+     ;; should appear *later* in the sequence.
      (let [roots (apply set/difference (set (keys m)) (map set (vals m)))]
        (when (empty? roots)
          (let [cs (->> m

--- a/src/lein_monolith/target.clj
+++ b/src/lein_monolith/target.clj
@@ -72,26 +72,26 @@
         skippable (resolve-projects subprojects (:skip opts))
         selector (combine-selectors monolith (:select opts))]
     (->
-      ; Start with explicitly-specified 'in' targets.
+      ;; Start with explicitly-specified 'in' targets.
       (resolve-projects subprojects (:in opts))
       (as-> targets
-        ; Merge all targeted upstream dependencies.
+        ;; Merge all targeted upstream dependencies.
         (->> (:upstream-of opts)
              (resolve-projects subprojects)
              (map (partial dep/upstream-keys dependencies))
              (reduce set/union targets))
-        ; Merge all targeted downstream dependencies.
+        ;; Merge all targeted downstream dependencies.
         (->> (:downstream-of opts)
              (resolve-projects subprojects)
              (map (partial dep/downstream-keys dependencies))
              (reduce set/union targets))
-        ; If target set empty, replace with full set.
+        ;; If target set empty, replace with full set.
         (if (empty? targets)
           (set (keys subprojects))
           targets))
       (cond->>
-        ; Exclude all 'skip' targets.
+        ;; Exclude all 'skip' targets.
         skippable (remove skippable)
-        ; Filter using the selector, if any.
+        ;; Filter using the selector, if any.
         selector (filter-selected subprojects selector))
       (set))))

--- a/src/lein_monolith/task/info.clj
+++ b/src/lein_monolith/task/info.clj
@@ -49,7 +49,7 @@
           dependencies (dep/dependency-map subprojects)
           targets (target/select monolith subprojects opts)
           prefix-len (inc (count (:root monolith)))]
-      ; IDEA: some kind of stats about dependency graph shape
+      ;; IDEA: some kind of stats about dependency graph shape
       (when-not (:bare opts)
         (printf "Internal projects (%d):\n" (count targets)))
       (doseq [subproject-name (dep/topological-sort dependencies targets)

--- a/src/lein_monolith/task/util.clj
+++ b/src/lein_monolith/task/util.clj
@@ -27,31 +27,31 @@
   (loop [opts {}
          args args]
     (if-not (and (first args) (.startsWith (str (first args)) ":"))
-      ; No more arguments to process, or not a keyword arg.
+      ;; No more arguments to process, or not a keyword arg.
       [opts args]
-      ; Parse keyword option arg.
+      ;; Parse keyword option arg.
       (let [kw (keyword (subs (first args) 1))
             multi-arg-count (get expected (keyword (str (name kw) \*)))
             arg-count (get expected kw multi-arg-count)]
         (cond
-          ; Unexpected option, halt parsing.
+          ;; Unexpected option, halt parsing.
           (nil? arg-count)
           [opts args]
 
-          ; Flag option.
+          ;; Flag option.
           (zero? arg-count)
           (recur (assoc opts kw true) (rest args))
 
-          ; Single-valued option.
+          ;; Single-valued option.
           (and (= 1 arg-count) (nil? multi-arg-count))
           (recur (assoc opts kw (first (rest args))) (drop 2 args))
 
-          ; Multi-spec option, join value list.
+          ;; Multi-spec option, join value list.
           multi-arg-count
           (recur (update opts kw (fnil into []) (take arg-count (rest args)))
                  (drop (inc arg-count) args))
 
-          ; Multi-arg (but not spec) option.
+          ;; Multi-arg (but not spec) option.
           :else
           (recur (assoc opts kw (vec (take arg-count (rest args))))
                  (drop (inc arg-count) args)))))))

--- a/test/lein_monolith/dependency_test.clj
+++ b/test/lein_monolith/dependency_test.clj
@@ -80,7 +80,8 @@
   [n m]
   (map #(into (array-map) (shuffle (seq %))) (repeat n m)))
 
-; Int -> [Deps SmallestCycles]
+
+;; Int -> [Deps SmallestCycles]
 (defn gen-dep-cycle
   "Create a dependency cycle of the specified size
   that also includes a cycle of length 3 (ie. between two deps).
@@ -88,7 +89,7 @@
   smallest dependency cycles."
   [size]
   {:pre [(<= 5 size)]}
-  ;comments assume size == 50
+  ;; comments assume size == 50
   (let [[cstart cend] ((juxt identity inc) (quot size 2))]
     [(into {}
            (map (fn [a]
@@ -125,9 +126,9 @@
   (is (= #{} (dep/unique-cycles {})))
   (is (= #{[2 2]} (dep/unique-cycles {2 #{2}})))
   (is (= #{} (dep/unique-cycles {1 #{2}})))
-  (doseq [size [5 10]] ;gen cycles of these sizes (higher is very slow)
+  (doseq [size [5 10]] ; gen cycles of these sizes (higher is very slow)
     (let [[deps smallest-cycles] (gen-dep-cycle size)]
-      (doseq [c (maps-like 10 deps)] ;shuffle deps order <..> times
+      (doseq [c (maps-like 10 deps)] ; shuffle deps order <..> times
         (let [actual (dep/unique-cycles c)]
           (every? #(is (cycle-actually-occurs deps %)
                        (str "Cycle doesn't occur:\n"
@@ -147,7 +148,7 @@
       (is (instance? IExceptionInfo e)
           (str "Didn't throw an exception\ndeps: " deps))
       (is (re-find #"Dependency cycles? detected" (.getMessage e)))
-      ; pretty printed dependency cycle appears in msg
+      ;; pretty printed dependency cycle appears in msg
       (is (->> e ex-data :cycles (some smlest-cycles))
           (str "Didn't include smallest cycle:\n"
                "deps: " deps "\n"
@@ -164,9 +165,9 @@
                      #{[:a :b :c :a]
                        [:b :c :a :b]
                        [:c :a :b :c]})
-  (doseq [size [5 10]] ;gen cycles of these sizes (higher is very slow)
+  (doseq [size [5 10]] ; gen cycles of these sizes (higher is very slow)
     (let [[deps smallest-cycles] (gen-dep-cycle size)]
-      (doseq [c (maps-like 5 deps)] ;shuffle deps order <..> times
+      (doseq [c (maps-like 5 deps)] ; shuffle deps order <..> times
         (check-cycle-error c smallest-cycles)))))
 
 


### PR DESCRIPTION
For our open source day, I'm bumping up the following dependencies:

- manifold (0.1.8 -> 0.2.4)
- lein-cloverage (1.2.1 -> 1.2.4)
- clojure (1.10.1 -> 1.10.3)
Clojure 1.11.1 is available, but I'm upgrading to 1.10.3 to maintain parity with the version Amperity uses elsewhere.

I also upgraded the cljstyle and clj-kondo versions CircleCI uses and fixed the linting errors that came from using the new versions.