### PR TITLE
Add show-fingerprints command

### DIFF
--- a/src/leiningen/monolith.clj
+++ b/src/leiningen/monolith.clj
@@ -250,6 +250,16 @@
     (fingerprint/mark-fresh project opts more)))
 
 
+(defn show-fingerprints
+  "Show information about the calculation of one or more projects'
+  fingerprints, compared to a current marker.
+
+  Usage:
+  lein monolith show-fingerprints marker project [...]"
+  [project [marker & args]]
+  (fingerprint/show project marker args))
+
+
 (defn clear-fingerprints
   "Clear projects' cached fingerprints so they will be re-built next :refresh.
 
@@ -270,7 +280,7 @@
   "Tasks for working with Leiningen projects inside a monorepo."
   {:subtasks [#'info #'lint #'deps #'deps-on #'deps-of #'graph
               #'with-all #'each #'link #'unlink
-              #'changed #'mark-fresh #'clear-fingerprints]}
+              #'changed #'mark-fresh #'show-fingerprints #'clear-fingerprints]}
   [project command & args]
   (case command
     "info"               (info project args)
@@ -285,6 +295,7 @@
     "unlink"             (unlink project args)
     "changed"            (changed project args)
     "mark-fresh"         (mark-fresh project args)
+    "show-fingerprints"  (show-fingerprints project args)
     "clear-fingerprints" (clear-fingerprints project args)
     (lein/abort (pr-str command) "is not a valid monolith command! Try: lein help monolith"))
   (flush))


### PR DESCRIPTION
Some more tooling I added while I was debugging our extra CI installs. This introduces a `lein monolith show-fingerprints <marker> <project> [project ...]` command which can be used to calculate some projects' current fingerprints and diff against the specified marker. As part of this, the fingerprint map will also start tracking the upstream prints that went into each project; this is a substantial increase in the size of the fingerprint file, but offers some invaluable insight into why things are considered to be changed.

Example output (ansi colors not shown):
```
% lein monolith show-fingerprints ci/build segment-core
amperity/segment-core
        version: MONOLITH-SNAPSHOT
           seed: 0
        sources: CgpMYFe8qqTUSTL-tJFidDHmTp0 => LNcY855XbPb1lxZ9Wv2dITopvlI
           deps: arJ2abX6PDfS8rg6OHkxAr9wnSI
   java-version: 11.0.11
       upstream: -PzwUOvtUXQUJWdE229Ip8cegOg => qO3gNRBBEzc3UcSmBMlkCq_7Bbc
                 * amperity/common: rYYWz9tadMp4TqGXI9vd7Z6-6pw
                 * amperity/database-core: nqqi143Hmrh3Xy7SDNDyKXgdaYM
                 * amperity/ent-client: C5M_BvZdVeN3B7-WQlydRgiYXFs
                 * amperity/ent-core: c4YvbpxptHL4kmpoS3-EAvu-FdA
                 * amperity/finagle-base: vRAcsOoaB_5Vy-4Euym5dqFRHtc => nvBpMzq4bkCcNWpkeQZt_CBN0e8
                 * amperity/query-core: lOFoUhqaBlYGIsvSokG2Thu4Xps
                 * amperity/sql: vG8G6NDSHWx9oL5VEYNciHoWcLs
          final: VUTPUON2vyx3OYJ_c-ubqaCMLW0 => Vffs-fX7youHqyx21MRM2nePNFo
```