### PR TITLE
Implement dependency set feature in lein-monolith

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## Added
+### Added
 - Dependency sets can now be defined in the metaproject, and projects can opt into
   them with the `:monolith/dependency-set` key.
   [#93](https://github.com/amperity/lein-monolith/pull/93)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-...
+## Added
+- Dependency sets can now be defined in the metaproject, and projects can opt into
+  them with the `:monolith/dependency-set` key.
 
 
 ## [1.8.0] - 2022-07-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Added
 - Dependency sets can now be defined in the metaproject, and projects can opt into
   them with the `:monolith/dependency-set` key.
+  [#93](https://github.com/amperity/lein-monolith/pull/93)
 
 
 ## [1.8.0] - 2022-07-13

--- a/doc/config.md
+++ b/doc/config.md
@@ -42,13 +42,46 @@ By using raw inheritance, you can safely inherit paths, e.g. `:test-paths` or
 
 ## Dependency Sets
 
-The `:monolith/dependency-set` key can be used to opt projects into a specific
-set of managed dependencies instead of using a single list of managed dependencies
-in the metaproject.
+The `:dependency-sets` key can be configured in the metaproject to provide child
+projects with a curated set of managed dependencies to opt into instead of using
+a single list of managed dependencies in the metaproject. This should be a map of
+dependency set names and their dependencies.
 
-Dependency sets are defined in the metaproject with the `:dependency-sets` key.
+For example, in the metaproject file we can define a dependency set
+called `:set-a` as follows:
+
+```clj
+(defproject lein-monolith.example/all "MONOLITH"
+
+...
+
+:monolith
+  {:dependency-sets
+   {:set-a
+    [[amperity/greenlight "0.7.1"]
+     [org.clojure/spec.alpha "0.3.218"]]}
+
+...
+
+)
+```
+
+The `:monolith/dependency-set` key can then be used to a opt child project into `:set-a` as follows:
+
+```clj
+(defproject lein-monolith.example/app-a "MONOLITH-SNAPSHOT"
+ 
+ ...
+
+ :monolith/dependency-set :set-a
+
+ ...
+
+)
+```
+
 By selecting a dependency set from the metaproject with `:monolith/dependency-set`,
 you will merge in a profile with `:managed-dependencies` set to the dependencies within
-the dependency set. If you also set the `:monolith/inherit` key in a project, this profile
+the dependency set. If you also configure the child project to use inherited profiles, this profile
 will be merged in *before* the inherited profiles. This means that dependency versions in
 a dependency set will have precedence over versions in an inherited `:managed-dependencies` key.

--- a/doc/config.md
+++ b/doc/config.md
@@ -39,3 +39,16 @@ Lastly, `lein-monolith` supports inheriting unprocessed values, via
 inheriting paths, as Leiningen absolutizes paths upon processing a project map.
 By using raw inheritance, you can safely inherit paths, e.g. `:test-paths` or
 `:source-paths`.
+
+## Dependency Sets
+
+The `:monolith/dependency-set` key can be used to opt projects into a specific
+set of managed dependencies instead of using a single list of managed dependencies
+in the metaproject.
+
+Dependency sets are defined in the metaproject with the `:dependency-sets` key.
+By selecting a dependency set from the metaproject with `:monolith/dependency-set`,
+you will merge in a profile with `:managed-dependencies` set to the dependencies within
+the dependency set. If you also set the `:monolith/inherit` key in a project, this profile
+will be merged in *before* the inherited profiles. This means that dependency versions in
+a dependency set will have precedence over versions in an inherited `:managed-dependencies` key.

--- a/example/apps/app-a/project.clj
+++ b/example/apps/app-a/project.clj
@@ -1,6 +1,7 @@
 (defproject lein-monolith.example/app-a "MONOLITH-SNAPSHOT"
   :description "Example project with internal and external dependencies."
   :monolith/inherit true
+  :monolith/dependency-set :set-a
   :deployable true
 
   :dependencies

--- a/example/libs/lib-a/project.clj
+++ b/example/libs/lib-a/project.clj
@@ -2,7 +2,5 @@
   :description "Example library with no internal dependencies."
   :monolith/inherit true
 
-  :pedantic? :abort
-
   :dependencies
   [[org.clojure/clojure "1.10.1"]])

--- a/example/project.clj
+++ b/example/project.clj
@@ -49,7 +49,11 @@
    :project-dirs
    ["apps/*"
     "libs/**"
-    "not-found"]}
+    "not-found"]
+
+   :dependency-sets
+   {:set-a
+    [[amperity/greenlight "0.7.1"]]}}
 
   :env
   {:foo "bar"})

--- a/example/project.clj
+++ b/example/project.clj
@@ -6,7 +6,7 @@
    "version++" ["version+"]}
 
   :plugins
-  [[lein-monolith "1.8.0"]
+  [[lein-monolith "1.9.0-SNAPSHOT"]
    [lein-pprint "1.2.0"]]
 
   :dependencies

--- a/example/project.clj
+++ b/example/project.clj
@@ -13,7 +13,8 @@
   [[org.clojure/clojure "1.10.1"]]
 
   :managed-dependencies
-  [[amperity/greenlight "0.6.0"]]
+  [[amperity/greenlight "0.6.0"]
+   [com.amperity/vault-clj "2.1.583"]]
 
   :test-selectors
   {:unit (complement :integration)
@@ -53,7 +54,8 @@
 
    :dependency-sets
    {:set-a
-    [[amperity/greenlight "0.7.1"]]}}
+    [[amperity/greenlight "0.7.1"]
+     [org.clojure/spec.alpha "0.3.218"]]}}
 
   :env
   {:foo "bar"})

--- a/example/project.clj
+++ b/example/project.clj
@@ -1,8 +1,6 @@
 (defproject lein-monolith.example/all "MONOLITH"
   :description "Overarching example project."
 
-  :pedantic? :ranges
-
   :aliases
   {"version+" ["version"]
    "version++" ["version+"]}

--- a/example/project.clj
+++ b/example/project.clj
@@ -1,6 +1,8 @@
 (defproject lein-monolith.example/all "MONOLITH"
   :description "Overarching example project."
 
+  :pedantic? :ranges
+
   :aliases
   {"version+" ["version"]
    "version++" ["version+"]}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-monolith "1.8.0"
+(defproject lein-monolith "1.9.0-SNAPSHOT"
   :description "Leiningen plugin for managing subrojects within a monorepo."
   :url "https://github.com/amperity/lein-monolith"
   :license {:name "Apache License 2.0"

--- a/src/lein_monolith/plugin.clj
+++ b/src/lein_monolith/plugin.clj
@@ -133,9 +133,9 @@
   [monolith subproject]
   ;; The dependency set profile should be the first profile, so that its managed dependencies
   ;; take precedence.
-  (concat
-    (build-dependency-profiles monolith subproject)
-    (build-inherited-profiles monolith subproject)))
+  (vec (concat
+         (build-dependency-profiles monolith subproject)
+         (build-inherited-profiles monolith subproject))))
 
 
 ;; ## Profile Utilities
@@ -179,12 +179,11 @@
   "Adds profiles to the project. Profiles should be passed in as a vector to ensure profiles are
    added in the right order."
   [project profiles]
-  (reduce (fn [project [profile-key profile]]
-            (-> project
-                (project/add-profiles {profile-key profile})
-                (project/merge-profiles [profile-key])))
-          project
-          profiles))
+  (if (empty? profiles)
+    project
+    (-> project
+        (project/add-profiles (into {} profiles))
+        (project/merge-profiles (mapv first profiles)))))
 
 
 (defn middleware

--- a/src/lein_monolith/plugin.clj
+++ b/src/lein_monolith/plugin.clj
@@ -184,7 +184,7 @@
            (:monolith/active (meta project)))
      ;; Normal project or already activated monolith subproject, don't activate.
      project
-     ;; Monolith subproject has not yet been activated, add inherited profiles.
+     ;; Monolith subproject has not yet been activated, add profiles.
      (let [monolith (or monolith (config/find-monolith! project))
            profiles (build-profiles monolith project)]
        (-> project
@@ -228,8 +228,8 @@
   (let [profile
         (reduce-kv
           (fn [profile _project-name subproject]
-            (let [with-inherited-profiles (middleware subproject monolith)
-                  project (project/absolutize-paths with-inherited-profiles)]
+            (let [with-profiles (middleware subproject monolith)
+                  project (project/absolutize-paths with-profiles)]
               (reduce (partial add-profile-paths project)
                       profile
                       path-keys)))

--- a/src/lein_monolith/plugin.clj
+++ b/src/lein_monolith/plugin.clj
@@ -119,9 +119,9 @@
   "Constructs a profile with managed dependencies from the subproject's dependency set.
    Returns nil if the subproject does not use a dependency set."
   [monolith subproject]
-  (when-let [dependency-set (:monolith/dependency-set (meta subproject))]
+  (when-let [dependency-set (:monolith/dependency-set subproject)]
     (let [dependencies (or (get-in monolith [:monolith :dependency-sets dependency-set])
-                           (lein/abort (format "Unknown dependency set %s for project %s" dependency-set (:name (meta subproject)))))]
+                           (lein/abort (format "Unknown dependency set %s for project %s" dependency-set (:name subproject))))]
       {:monolith/dependency-set
        (vary-meta {:managed-dependencies dependencies} assoc :leaky true)})))
 
@@ -129,8 +129,11 @@
 (defn build-profiles
   "Constructs a map of profile keys to inherited profile maps and the dependency set profile map"
   [monolith subproject]
-  (merge (build-inherited-profiles monolith subproject)
-         (build-dependency-set-profile monolith subproject)))
+  (merge
+    ;; The dependency set profile should be the first profile, so that its managed dependencies
+    ;; take precedence.
+    (build-dependency-set-profile monolith subproject)
+    (build-inherited-profiles monolith subproject)))
 
 
 ;; ## Profile Utilities

--- a/src/lein_monolith/plugin.clj
+++ b/src/lein_monolith/plugin.clj
@@ -115,13 +115,13 @@
     profile-config))
 
 
-(defn build-dependency-set-profile
-  "Constructs a profile with managed dependencies from the subproject's dependency set.
+(defn build-dependency-profiles
+  "Constructs a map with a profile containing managed dependencies from the subproject's chosen dependency set.
    Returns nil if the subproject does not use a dependency set."
   [monolith subproject]
   (when-let [dependency-set (:monolith/dependency-set subproject)]
     (let [dependencies (or (get-in monolith [:monolith :dependency-sets dependency-set])
-                           (lein/abort (format "Unknown dependency set %s for project %s" dependency-set (:name subproject))))]
+                           (lein/abort (format "Unknown dependency set %s used in project %s" dependency-set (:name subproject))))]
       {:monolith/dependency-set
        ^:leaky {:managed-dependencies dependencies}})))
 
@@ -132,7 +132,7 @@
   (merge
     ;; The dependency set profile should be the first profile, so that its managed dependencies
     ;; take precedence.
-    (build-dependency-set-profile monolith subproject)
+    (build-dependency-profiles monolith subproject)
     (build-inherited-profiles monolith subproject)))
 
 

--- a/src/lein_monolith/plugin.clj
+++ b/src/lein_monolith/plugin.clj
@@ -103,17 +103,16 @@
 (defn build-inherited-profiles
   "Returns a map from profile keys to inherited profile maps."
   [monolith subproject]
-  (when (:monolith/inherit subproject)
-    (reduce
-      (fn [acc [key config]]
-        (let [profile (some-> (choose-inheritance-source monolith config)
-                              (inherited-profile subproject config)
-                              (maybe-mark-leaky config))]
-          (if profile
-            (assoc acc key profile)
-            acc)))
-      nil
-      profile-config)))
+  (reduce
+    (fn [acc [key config]]
+      (let [profile (some-> (choose-inheritance-source monolith config)
+                            (inherited-profile subproject config)
+                            (maybe-mark-leaky config))]
+        (if profile
+          (assoc acc key profile)
+          acc)))
+    nil
+    profile-config))
 
 
 (defn build-dependency-set-profile

--- a/src/lein_monolith/task/fingerprint.clj
+++ b/src/lein_monolith/task/fingerprint.clj
@@ -287,9 +287,10 @@
                             (fn inherit-profiles
                               [[k subproject]]
                               [k
-                               (update subproject :profiles concat
-                                       (plugin/build-profiles
-                                         monolith subproject))]))
+                               (update subproject :profiles merge
+                                       (into {}
+                                             (plugin/build-profiles
+                                               monolith subproject)))]))
                           subprojects)]
     {:root root
      :subprojects subprojects

--- a/src/lein_monolith/task/fingerprint.clj
+++ b/src/lein_monolith/task/fingerprint.clj
@@ -287,8 +287,8 @@
                             (fn inherit-profiles
                               [[k subproject]]
                               [k
-                               (update subproject :profiles merge
-                                       (plugin/build-inherited-profiles
+                               (update subproject :profiles concat
+                                       (plugin/build-profiles
                                          monolith subproject))]))
                           subprojects)]
     {:root root

--- a/test/lein_monolith/plugin_test.clj
+++ b/test/lein_monolith/plugin_test.clj
@@ -13,7 +13,7 @@
 (deftest build-inherited-profiles-test
   (let [monolith (config/find-monolith! (read-example-project))
         subproject (project/read "example/apps/app-a/project.clj")
-        profiles (plugin/build-inherited-profiles monolith subproject)]
+        profiles (into {} (plugin/build-inherited-profiles monolith subproject))]
     (is (= #{:monolith/inherited
              :monolith/inherited-raw
              :monolith/leaky
@@ -35,7 +35,7 @@
 (deftest build-dependency-set-profile-test
   (let [monolith (config/find-monolith! (read-example-project))
         subproject (project/read "example/apps/app-a/project.clj")
-        profile (plugin/build-dependency-profiles monolith subproject)]
+        profile (into {} (plugin/build-dependency-profiles monolith subproject))]
     (is (= :set-a (:monolith/dependency-set subproject)))
     (is (= [['amperity/greenlight "0.7.1"] ['org.clojure/spec.alpha "0.3.218"]]
            (get-in monolith [:monolith :dependency-sets :set-a])))

--- a/test/lein_monolith/plugin_test.clj
+++ b/test/lein_monolith/plugin_test.clj
@@ -13,12 +13,11 @@
 (deftest build-inherited-profiles-test
   (let [monolith (config/find-monolith! (read-example-project))
         subproject (project/read "example/apps/app-a/project.clj")
-        profiles (plugin/build-profiles monolith subproject)]
+        profiles (plugin/build-inherited-profiles monolith subproject)]
     (is (= #{:monolith/inherited
              :monolith/inherited-raw
              :monolith/leaky
-             :monolith/leaky-raw
-             :monolith/dependency-set}
+             :monolith/leaky-raw}
            (set (keys profiles))))
     (is (= {:test-paths ["test/unit" "test/integration"]}
            (:monolith/inherited-raw profiles)))
@@ -27,9 +26,27 @@
               {:url "https://repo1.maven.org/maven2/"
                :snapshots false}]
              ["clojars" {:url "https://repo.clojars.org/"}]]
-            :managed-dependencies [['amperity/greenlight "0.6.0"]]}
+            :managed-dependencies [['amperity/greenlight "0.6.0"] ['com.amperity/vault-clj "2.1.583"]]}
            (:monolith/leaky profiles)))
     (is (= {:compile-path "%s/compiled"}
-           (:monolith/leaky-raw profiles)))
-    (is (= {:managed-dependencies [['amperity/greenlight "0.7.1"]]}
-           (:monolith/dependency-set profiles)))))
+           (:monolith/leaky-raw profiles)))))
+
+
+(deftest build-dependency-set-profile-test
+  (let [monolith (config/find-monolith! (read-example-project))
+        subproject (project/read "example/apps/app-a/project.clj")
+        profile (plugin/build-dependency-set-profile monolith subproject)]
+    (is (= :set-a (:monolith/dependency-set subproject)))
+    (is (= [['amperity/greenlight "0.7.1"] ['org.clojure/spec.alpha "0.3.218"]]
+           (get-in monolith [:monolith :dependency-sets :set-a])))
+    (is (= [['amperity/greenlight "0.7.1"] ['org.clojure/spec.alpha "0.3.218"]]
+           (get-in profile [:monolith/dependency-set :managed-dependencies])))))
+
+
+(deftest managed-dependencies-order
+  (let [subproject (project/read "example/apps/app-a/project.clj")]
+    (is (= '([amperity/greenlight "0.7.1"] ; This version of greenlight should come first so it'll take precedence over any other versions
+             [org.clojure/spec.alpha "0.3.218"]
+             [amperity/greenlight "0.6.0"]
+             [com.amperity/vault-clj "2.1.583"])
+           (:managed-dependencies subproject)))))

--- a/test/lein_monolith/plugin_test.clj
+++ b/test/lein_monolith/plugin_test.clj
@@ -13,11 +13,12 @@
 (deftest build-inherited-profiles-test
   (let [monolith (config/find-monolith! (read-example-project))
         subproject (project/read "example/apps/app-a/project.clj")
-        profiles (plugin/build-inherited-profiles monolith subproject)]
+        profiles (plugin/build-profiles monolith subproject)]
     (is (= #{:monolith/inherited
              :monolith/inherited-raw
              :monolith/leaky
-             :monolith/leaky-raw}
+             :monolith/leaky-raw
+             :monolith/dependency-set}
            (set (keys profiles))))
     (is (= {:test-paths ["test/unit" "test/integration"]}
            (:monolith/inherited-raw profiles)))
@@ -29,4 +30,6 @@
             :managed-dependencies [['amperity/greenlight "0.6.0"]]}
            (:monolith/leaky profiles)))
     (is (= {:compile-path "%s/compiled"}
-           (:monolith/leaky-raw profiles)))))
+           (:monolith/leaky-raw profiles)))
+    (is (= {:managed-dependencies [['amperity/greenlight "0.7.1"]]}
+           (:monolith/dependency-set profiles)))))

--- a/test/lein_monolith/plugin_test.clj
+++ b/test/lein_monolith/plugin_test.clj
@@ -44,7 +44,9 @@
 
 
 (deftest managed-dependencies-order
-  (let [subproject (project/read "example/apps/app-a/project.clj")]
+  (let [monolith (config/find-monolith! (read-example-project))
+        subproject (-> (project/read "example/apps/app-a/project.clj")
+                       (plugin/middleware monolith))]
     (is (= '([amperity/greenlight "0.7.1"] ; This version of greenlight should come first so it'll take precedence over any other versions
              [org.clojure/spec.alpha "0.3.218"]
              [amperity/greenlight "0.6.0"]

--- a/test/lein_monolith/plugin_test.clj
+++ b/test/lein_monolith/plugin_test.clj
@@ -35,7 +35,7 @@
 (deftest build-dependency-set-profile-test
   (let [monolith (config/find-monolith! (read-example-project))
         subproject (project/read "example/apps/app-a/project.clj")
-        profile (plugin/build-dependency-set-profile monolith subproject)]
+        profile (plugin/build-dependency-profiles monolith subproject)]
     (is (= :set-a (:monolith/dependency-set subproject)))
     (is (= [['amperity/greenlight "0.7.1"] ['org.clojure/spec.alpha "0.3.218"]]
            (get-in monolith [:monolith :dependency-sets :set-a])))


### PR DESCRIPTION
We'd like to implement support for dependency sets in lein-monolith to help us cleanly cutover projects to newer versions of our managed dependencies.

To this end, this PR implements support for the following:

- Defining dependency sets in the metaproject file
- Opting into a dependency set in a child project using `:monolith/dependency-set`
   - Opting into a dependency set merges in a profile with `:managed-dependencies` populated from the dependency set
   - This profile is merged before any of the inherited profiles
   - `:monolith/dependency-set` can be used independently of `:monolith/inherit`

I added some unit tests to ensure the managed dependencies (and their order) are set correctly when a dependency set is used. I also did some local testing with projects to check that dependencies from a dependency set are passed onto the generated pom file.