### PR TITLE
Include :jar-exclusions in fingerprints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file, which
 follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- Subproject fingerprints now include `:jar-exclusions` in the calculation.
+  [#95](https://github.com/amperity/lein-monolith/pull/95)
 
 ## [1.9.0] - 2023-12-07
 
@@ -342,7 +347,8 @@ instead of loading them all before running any commands.
 Initial project release
 
 
-[Unreleased]: https://github.com/amperity/lein-monolith/compare/1.8.0...HEAD
+[Unreleased]: https://github.com/amperity/lein-monolith/compare/1.9.0...HEAD
+[1.9.0]: https://github.com/amperity/lein-monolith/compare/1.8.0...1.9.0
 [1.8.0]: https://github.com/amperity/lein-monolith/compare/1.7.1...1.8.0
 [1.7.1]: https://github.com/amperity/lein-monolith/compare/1.7.0...1.7.1
 [1.7.0]: https://github.com/amperity/lein-monolith/compare/1.6.1...1.7.0

--- a/example/project.clj
+++ b/example/project.clj
@@ -6,7 +6,7 @@
    "version++" ["version+"]}
 
   :plugins
-  [[lein-monolith "1.9.0"]
+  [[lein-monolith "1.9.1-SNAPSHOT"]
    [lein-pprint "1.2.0"]]
 
   :dependencies

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-monolith "1.9.0"
+(defproject lein-monolith "1.9.1-SNAPSHOT"
   :description "Leiningen plugin for managing subrojects within a monorepo."
   :url "https://github.com/amperity/lein-monolith"
   :license {:name "Apache License 2.0"

--- a/src/lein_monolith/task/fingerprint.clj
+++ b/src/lein_monolith/task/fingerprint.clj
@@ -200,6 +200,17 @@
         (dep-map (dep/project-name project))))
 
 
+(defn- hash-jar-exclusions
+  [project]
+  (kv-hash
+    :jar-exclusions
+    (into
+      {}
+      (map (fn [[profile-key profile]]
+             [profile-key (pr-str (:jar-exclusions profile))]))
+      (assoc (:profiles project) ::default project))))
+
+
 (defn- hash-inputs
   "Hashes each of a project's inputs, and returns a map containing each individual
   result, so it's easier to explain what aspect of a project caused its overall
@@ -217,7 +228,7 @@
               prints
               {::version (str (:version project))
                ::java-version (System/getProperty "java.version")
-               ::jar-exclusions (pr-str (:jar-exclusions project))
+               ::jar-exclusions (hash-jar-exclusions project)
                ::seed (str (:monolith/fingerprint-seed project 0))
                ::sources (hash-sources project)
                ::deps (hash-dependencies project)
@@ -335,7 +346,7 @@
    ::new-project ["is a new project" "are new projects" :red]
    ::version ["has a different version" "have different versions" :red]
    ::java-version ["has a different java version" "have different java versions" :red]
-   ::jar-exclusions ["has changed JAR exclusions" "have changed JAR exclusions" :red]
+   ::jar-exclusions ["has different JAR exclusions" "have different JAR exclusions" :red]
    ::seed ["has a different seed" "have different seeds" :yellow]
    ::sources ["has updated sources" "have updated sources" :red]
    ::deps ["has updated external dependencies" "have updated external dependencies" :yellow]

--- a/src/lein_monolith/task/fingerprint.clj
+++ b/src/lein_monolith/task/fingerprint.clj
@@ -337,8 +337,8 @@
    ::sources
    ::deps
    ::java-version
-   ::upstream
-   ::jar-exclusions])
+   ::jar-exclusions
+   ::upstream])
 
 
 (def ^:private reason-details
@@ -346,7 +346,7 @@
    ::new-project ["is a new project" "are new projects" :red]
    ::version ["has a different version" "have different versions" :red]
    ::java-version ["has a different java version" "have different java versions" :red]
-   ::jar-exclusions ["has different JAR exclusions" "have different JAR exclusions" :red]
+   ::jar-exclusions ["has different JAR exclusions" "have different JAR exclusions" :yellow]
    ::seed ["has a different seed" "have different seeds" :yellow]
    ::sources ["has updated sources" "have updated sources" :red]
    ::deps ["has updated external dependencies" "have updated external dependencies" :yellow]

--- a/src/lein_monolith/task/fingerprint.clj
+++ b/src/lein_monolith/task/fingerprint.clj
@@ -217,6 +217,7 @@
               prints
               {::version (str (:version project))
                ::java-version (System/getProperty "java.version")
+               ::jar-exclusions (pr-str (:jar-exclusions project))
                ::seed (str (:monolith/fingerprint-seed project 0))
                ::sources (hash-sources project)
                ::deps (hash-dependencies project)
@@ -325,7 +326,8 @@
    ::sources
    ::deps
    ::java-version
-   ::upstream])
+   ::upstream
+   ::jar-exclusions])
 
 
 (def ^:private reason-details
@@ -333,6 +335,7 @@
    ::new-project ["is a new project" "are new projects" :red]
    ::version ["has a different version" "have different versions" :red]
    ::java-version ["has a different java version" "have different java versions" :red]
+   ::jar-exclusions ["has changed JAR exclusions" "have changed JAR exclusions" :red]
    ::seed ["has a different seed" "have different seeds" :yellow]
    ::sources ["has updated sources" "have updated sources" :red]
    ::deps ["has updated external dependencies" "have updated external dependencies" :yellow]


### PR DESCRIPTION
`:jar-exclusions` can alter the contents of a project's JAR file, so when it's changed the project should be considered stale.