### PR TITLE
Update subproject clean targets with absolute paths

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,7 @@ jobs:
             - v1-test-
       - run: lein deps
       - run: lein check
+      - run: lein install
       - run: lein with-profile +ci test2junit
       - run: rm -r ~/.m2/repository/lein-monolith
       - store_test_results:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-...
+### Changed
+- Subproject `:clean-targets` will automatically be updated with absolute paths to support running
+  the `clean` task as part of `lein monolith each`.
+  [#99](https://github.com/amperity/lein-monolith/pull/99)
 
 
 ## [1.10.0] - 2024-06-03

--- a/example/libs/lib-b/project.clj
+++ b/example/libs/lib-b/project.clj
@@ -4,4 +4,6 @@
 
   :dependencies
   [[org.clojure/clojure "1.10.1"]
-   [lein-monolith.example/lib-a "MONOLITH-SNAPSHOT"]])
+   [lein-monolith.example/lib-a "MONOLITH-SNAPSHOT"]]
+
+  :clean-targets ^{:protect false} ["target" "resources"])

--- a/example/project.clj
+++ b/example/project.clj
@@ -6,7 +6,7 @@
    "version++" ["version+"]}
 
   :plugins
-  [[lein-monolith "1.10.0"]
+  [[lein-monolith "1.10.1-SNAPSHOT"]
    [lein-pprint "1.2.0"]]
 
   :dependencies

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-monolith "1.10.0"
+(defproject lein-monolith "1.10.1-SNAPSHOT"
   :description "Leiningen plugin for managing subrojects within a monorepo."
   :url "https://github.com/amperity/lein-monolith"
   :license {:name "Apache License 2.0"

--- a/test/lein_monolith/config_test.clj
+++ b/test/lein_monolith/config_test.clj
@@ -1,0 +1,20 @@
+(ns lein-monolith.config-test
+  (:require
+    [clojure.java.io :as io]
+    [clojure.test :refer [deftest is testing]]
+    [lein-monolith.config :as config]
+    [lein-monolith.test-utils :refer [read-example-project]]))
+
+
+(deftest read-subprojects
+  (testing "subproject clean targets use absolute paths"
+    (let [monolith (read-example-project)
+          subprojects (config/read-subprojects! monolith)
+          test-project (get subprojects 'lein-monolith.example/lib-b)
+          clean-targets (:clean-targets test-project)]
+      (is (map? test-project)
+          "lib-b subproject was loaded")
+      (is (= {:protect false} (meta clean-targets))
+          "metadata is preserved")
+      (is (= (set clean-targets) (set (filter #(.isAbsolute (io/file %)) clean-targets)))
+          "All clean target paths are absolute"))))

--- a/test/lein_monolith/task/each_test.clj
+++ b/test/lein_monolith/task/each_test.clj
@@ -20,19 +20,19 @@
   (testing "Verify that the clean targets for each subproject are cleaned up by `lein monolith each clean`."
     (let [monolith (read-example-project)
           subprojects (config/read-subprojects! monolith)]
-      (doseq [[_subproject-name subproject] subprojects]
-        (doseq [target (:clean-targets subproject)]
-          (let [path (test-path subproject target)]
-            (is (str/starts-with? path (:root subproject))
-                "The test file path should be created within the subproject directory.")
-            (io/make-parents path)
-            (spit path "test")
-            (is (.exists (io/file path)) "The test file should have been created."))))
+      (doseq [[_subproject-name subproject] subprojects
+              target (:clean-targets subproject)]
+        (let [path (test-path subproject target)]
+          (is (str/starts-with? path (:root subproject))
+              "The test file path should be created within the subproject directory.")
+          (io/make-parents path)
+          (spit path "test")
+          (is (.exists (io/file path)) "The test file should have been created.")))
       (each/run-tasks monolith {} ["clean"]) ; lein monolith each clean
-      (doseq [[_subproject-name subproject] subprojects]
-        (doseq [target (:clean-targets subproject)]
-          (let [path (test-path subproject target)
-                test-file (io/file path)
-                parent-dir (io/file (.getParent test-file))]
-            (is (not (.exists test-file)) "The test file should not exist after a lein clean")
-            (is (not (.exists parent-dir)) "The target directory should not exist after a lein clean")))))))
+      (doseq [[_subproject-name subproject] subprojects
+              target (:clean-targets subproject)]
+        (let [path (test-path subproject target)
+              test-file (io/file path)
+              parent-dir (io/file (.getParent test-file))]
+          (is (not (.exists test-file)) "The test file should not exist after a lein clean")
+          (is (not (.exists parent-dir)) "The target directory should not exist after a lein clean"))))))

--- a/test/lein_monolith/task/each_test.clj
+++ b/test/lein_monolith/task/each_test.clj
@@ -1,0 +1,38 @@
+(ns lein-monolith.task.each-test
+  (:require
+    [clojure.java.io :as io]
+    [clojure.string :as str]
+    [clojure.test :refer [deftest is testing]]
+    [lein-monolith.config :as config]
+    [lein-monolith.task.each :as each]
+    [lein-monolith.test-utils :refer [read-example-project]]))
+
+
+(defn- test-path
+  "Returns the path where the test file should exist for the given target path."
+  [subproject target]
+  (if (= :target-path target)
+    (str (:root subproject) "/target/test.txt")
+    (str target "/test.txt")))
+
+
+(deftest clean-subprojects
+  (testing "Verify that the clean targets for each subproject are cleaned up by `lein monolith each clean`."
+    (let [monolith (read-example-project)
+          subprojects (config/read-subprojects! monolith)]
+      (doseq [[_subproject-name subproject] subprojects]
+        (doseq [target (:clean-targets subproject)]
+          (let [path (test-path subproject target)]
+            (is (str/starts-with? path (:root subproject))
+                "The test file path should be created within the subproject directory.")
+            (io/make-parents path)
+            (spit path "test")
+            (is (.exists (io/file path)) "The test file should have been created."))))
+      (each/run-tasks monolith {} ["clean"]) ; lein monolith each clean
+      (doseq [[_subproject-name subproject] subprojects]
+        (doseq [target (:clean-targets subproject)]
+          (let [path (test-path subproject target)
+                test-file (io/file path)
+                parent-dir (io/file (.getParent test-file))]
+            (is (not (.exists test-file)) "The test file should not exist after a lein clean")
+            (is (not (.exists parent-dir)) "The target directory should not exist after a lein clean")))))))


### PR DESCRIPTION
When running a command like `lein monolith each do clean, install`, any subprojects that provide relative paths for their clean targets will clean from the working directory that lein monolith was called from, instead of the root of the subproject (see https://github.com/technomancy/leiningen/issues/2707). Leiningen seems to handle relative paths for other config values like target path and source path, but seems like clean targets is the odd one out.

We can work around this issue by prepending the clean target paths with the root of the subproject as we're loading the project maps, which seems ok enough to me.

Tested this by adding a unit test, and also confirmed that `lein monolith each clean` cleans the right directories after this change.