### PR TITLE
Add option for `each` to run tasks in parallel ignoring dependency order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
-- Add an option `:parallel-unordered` to the `each` task that
+- Add an option `:no-dep-order` to the `each` task that
   processes projects in parallel as quickly as possible, ignoring dependency order.
 
 ## [1.10.1] - 2024-10-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-...
-
+### Added
+- Add an option `:parallel-unordered` to the `each` task that
+  processes projects in parallel as quickly as possible, ignoring dependency order.
 
 ## [1.10.1] - 2024-10-15
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ In addition to targeting options, `each` accepts:
 - `:report` show a detailed timing report after the tasks finish executing.
 - `:silent` suppress task output for successful projects.
 - `:output` path to a directory to save individual build output in.
+- `:parallel-unordered` like `:parallel`, but processes projects
+  as quickly as possible, ignoring dependency order.
 
 #### Incremental Builds
 

--- a/README.md
+++ b/README.md
@@ -113,8 +113,10 @@ In addition to targeting options, `each` accepts:
 - `:report` show a detailed timing report after the tasks finish executing.
 - `:silent` suppress task output for successful projects.
 - `:output` path to a directory to save individual build output in.
-- `:parallel-unordered` like `:parallel`, but processes projects
-  as quickly as possible, ignoring dependency order.
+- `:no-dep-order` normally `each` processes projects in dependency order
+  using a topological sort. With this option, projects are processed
+  without any respect to dependency order. This offers a speedup for
+  tasks that are not sensitive to dependency order.
 
 #### Incremental Builds
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-monolith "1.10.1"
+(defproject lein-monolith "1.11.0-SNAPSHOT"
   :description "Leiningen plugin for managing subrojects within a monorepo."
   :url "https://github.com/amperity/lein-monolith"
   :license {:name "Apache License 2.0"

--- a/src/leiningen/monolith.clj
+++ b/src/leiningen/monolith.clj
@@ -156,12 +156,10 @@
     :report                 Print a detailed timing report after running tasks.
     :silent                 Don't print task output unless a subproject fails.
     :output <path>          Save each project's individual output in the given directory.
-
-    :no-dep-order Ignore dependency ordering. This can yield
-                         a speedup for some shapes of depdendency graphs,
-                         but should only be used for tasks for which project order
-                         doesn't matter. Otherwise, it will produce errors or incorrect results!
-                         Mutually exclusive with `:parallel`.
+    :no-dep-order           Ignore dependency ordering. This can yield a speedup for some
+                            shapes of depdendency graphs, but should only be used for tasks for which
+                            project order doesn't matter. Otherwise, it will produce errors or incorrect
+                            results!
 
   Targeting Options:
     :in <names>             Add the named projects directly to the targets.

--- a/src/leiningen/monolith.clj
+++ b/src/leiningen/monolith.clj
@@ -157,6 +157,13 @@
     :silent                 Don't print task output unless a subproject fails.
     :output <path>          Save each project's individual output in the given directory.
 
+    :parallel-unordered <threads> Like `:parallel`, but process projects as quickly
+                                  as possible, ignoring dependency order. This can yield
+                                  a speedup for some shapes of depdendency graphs,
+                                  but should only be used for tasks for which project order
+                                  doesn't matter. Otherwise, it will produce errors or incorrect results!
+                                  Mutually exclusive with `:parallel`.
+
   Targeting Options:
     :in <names>             Add the named projects directly to the targets.
     :upstream               Add the transitive dependencies of the current project to the targets.
@@ -183,8 +190,10 @@
   (let [[opts task] (u/parse-kw-args each/task-opts args)]
     (when (empty? task)
       (lein/abort "Cannot run each without a task argument!"))
-    (when (and (:start opts) (:parallel opts))
-      (lein/abort "The :parallel and :start options are not compatible!"))
+    (when (and (:start opts) (or (:parallel opts) (:parallel-unordered opts)))
+      (lein/abort "The :start option is not compatible with parallel processing!"))
+    (when (and (:parallel opts) (:parallel-unordered opts))
+      (lein/abort "The :parallel and :parallel-unordered options cannot be used at the same time!"))
     (each/run-tasks project opts task)))
 
 

--- a/src/leiningen/monolith.clj
+++ b/src/leiningen/monolith.clj
@@ -157,12 +157,11 @@
     :silent                 Don't print task output unless a subproject fails.
     :output <path>          Save each project's individual output in the given directory.
 
-    :parallel-unordered <threads> Like `:parallel`, but process projects as quickly
-                                  as possible, ignoring dependency order. This can yield
-                                  a speedup for some shapes of depdendency graphs,
-                                  but should only be used for tasks for which project order
-                                  doesn't matter. Otherwise, it will produce errors or incorrect results!
-                                  Mutually exclusive with `:parallel`.
+    :no-dep-order Ignore dependency ordering. This can yield
+                         a speedup for some shapes of depdendency graphs,
+                         but should only be used for tasks for which project order
+                         doesn't matter. Otherwise, it will produce errors or incorrect results!
+                         Mutually exclusive with `:parallel`.
 
   Targeting Options:
     :in <names>             Add the named projects directly to the targets.
@@ -190,10 +189,8 @@
   (let [[opts task] (u/parse-kw-args each/task-opts args)]
     (when (empty? task)
       (lein/abort "Cannot run each without a task argument!"))
-    (when (and (:start opts) (or (:parallel opts) (:parallel-unordered opts)))
+    (when (and (:start opts) (:parallel opts))
       (lein/abort "The :start option is not compatible with parallel processing!"))
-    (when (and (:parallel opts) (:parallel-unordered opts))
-      (lein/abort "The :parallel and :parallel-unordered options cannot be used at the same time!"))
     (each/run-tasks project opts task)))
 
 

--- a/test/example-tests.sh
+++ b/test/example-tests.sh
@@ -40,7 +40,7 @@ test_monolith each :parallel 3 :report :endure pprint :group
 test_monolith each :refresh foo install
 test_monolith each :refresh foo install
 test_monolith each :parallel 3 :refresh bar install
-test_monolith each :parallel-unordered 3 test
+test_monolith each :parallel :no-dep-order 3 test
 test_monolith changed
 test_monolith clear-fingerprints :upstream-of lib-b
 test_monolith mark-fresh :upstream-of lib-b foo bar

--- a/test/example-tests.sh
+++ b/test/example-tests.sh
@@ -40,6 +40,7 @@ test_monolith each :parallel 3 :report :endure pprint :group
 test_monolith each :refresh foo install
 test_monolith each :refresh foo install
 test_monolith each :parallel 3 :refresh bar install
+test_monolith each :parallel-unordered 3 test
 test_monolith changed
 test_monolith clear-fingerprints :upstream-of lib-b
 test_monolith mark-fresh :upstream-of lib-b foo bar


### PR DESCRIPTION
`lein monolith each :parallel N` processes projects in dependency order, which is necessary for some tasks such as `install`, though for other tasks such as unit tests, or doc generation, dependency ordering is not required and things could be a bit faster by removing the dependency ordering.

In a CI/CD pipeline you could, for example, have a first phase that `install`s all projects using `:parallel N`, then subsequent phases that process projects using `:parallel N :no-dep-order`.

I'm not strongly attached to the name of the option, very open to suggestions.