### PR TITLE
Set initial thread count to avoid running tasks sequentially for 10 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-...
+### Fixed
+- Fixed a bug where `each :parallel <threads>` would run tasks
+  sequentially for the first 10 seconds.
 
 
 ## [1.10.1] - 2024-10-15

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-monolith "1.10.1"
+(defproject lein-monolith "1.10.2-SNAPSHOT"
   :description "Leiningen plugin for managing subrojects within a monorepo."
   :url "https://github.com/amperity/lein-monolith"
   :license {:name "Apache License 2.0"

--- a/src/lein_monolith/task/each.clj
+++ b/src/lein_monolith/task/each.clj
@@ -344,7 +344,7 @@
   order. Returns a vector of result maps in the order the tasks finished executing."
   [ctx threads targets]
   (let [deps (partial dep/upstream-keys (dep/dependency-map (:subprojects ctx)))
-        thread-pool (executor/fixed-thread-executor threads)]
+        thread-pool (executor/fixed-thread-executor threads {:initial-thread-count threads})]
     (resolve-tasks (:monolith ctx) (:task ctx))
     (->
       (reduce


### PR DESCRIPTION
The default for a manifold fixed thread pool is that it starts with 1 thread, and then every `control-period` adjusts the thread count. The default `control-period` is 10 seconds, so for the first 10 seconds, `each :parallel` will process projects sequentially. Let's set `:initial-thread-count` to the desired number of threads to start with the full desired parallelism.