### PR TITLE
Add "self" hash to fingerprints

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-monolith "1.10.4"
+(defproject lein-monolith "1.10.5-SNAPSHOT"
   :description "Leiningen plugin for managing subrojects within a monorepo."
   :url "https://github.com/amperity/lein-monolith"
   :license {:name "Apache License 2.0"

--- a/src/lein_monolith/task/fingerprint.clj
+++ b/src/lein_monolith/task/fingerprint.clj
@@ -236,6 +236,9 @@
               prints
               (assoc prints
                      ::upstream-hashes upstream-hashes
+                     ;; ::self is a hash of everything _except_ upstream stuff.
+                     ;; standalone hash that only changes when this projects itself changed.
+                     ::self (kv-hash :self (dissoc prints ::upstream))
                      ::final (kv-hash :inputs prints)
                      ::time (System/currentTimeMillis))]
           (swap! cache assoc project-name prints)


### PR DESCRIPTION
Exploring an idea of having lein-monolith command execution rewrite "MONOLITH-SNAPSHOT" versions into a project hash. The thing it rewrites to will be similar to lein-monolith's current notion of fingerprints, _except_ it does not fold in upstream project hashes.